### PR TITLE
Minor doc improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,21 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+document-features = { version = "0.2", optional = true }
 
 [features]
+## Enables bindings to `hilog`
 hilog = []
+## Enables bindings to `napi`
 napi = []
+## Enables bindings to `native_buffer`
 native_buffer = []
+## Enables bindings to `native_window`
 native_window = []
+## Enables bindings to `native_xcomponent`
 xcomponent = []
+## Document available features when building the documentation
+document-features = ["dep:document-features"]
+
+[package.metadata.docs.rs]
+features = ["document-features"]

--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -33,6 +33,9 @@ fi
 export LIBCLANG_PATH=${OHOS_NDK_HOME}/llvm/lib
 export CLANG_PATH=${OHOS_NDK_HOME}/llvm/bin/clang
 
+OHOS_API_VERSION=$(jq '.apiVersion' -j < "${OHOS_NDK_HOME}/oh-uni-package.json")
+echo "Generating bindings for API version ${OHOS_API_VERSION}"
+
 BASE_BINDGEN_ARGS=(--no-layout-tests --formatter=prettyplease)
 BASE_BINDGEN_ARGS+=(--blocklist-file='.*stdint\.h' --blocklist-file='.*stddef\.h')
 BASE_BINDGEN_ARGS+=(--blocklist-file='.*stdarg\.h' --blocklist-file='.*stdbool\.h')
@@ -45,6 +48,8 @@ BASE_BINDGEN_ARGS+=(--raw-line="#![allow(non_camel_case_types)]" --raw-line="#![
 # TODO: How to detect / deal with target specific bindings
 BASE_CLANG_ARGS=("--sysroot=${OHOS_SYSROOT_DIR}")
 BASE_CLANG_ARGS+=(--target=aarch64-linux-ohos)
+# So our wrapper headers can detect the API version (and conditionally include more header files)
+BASE_CLANG_ARGS+=("-DOHOS_SYS_API_LEVEL=${OHOS_API_VERSION}")
 
 
 bindgen "${BASE_BINDGEN_ARGS[@]}" \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,11 @@
 //!
 //! Note: There are currently still quite a few missing bindings, which will slowly be added.
 //!
-//! ## Features:
-//!
-//! - **hilog**: Raw bindings to hilog
-//! - **napi**: Raw bindings to napi
-//! - **native_buffer**: Raw bindings to `native_buffer`.
-//! - **native_window**: Raw bindings to `native_window`.
-//! - **xcomponent**: Raw bindings to `native_xcomponent`.
+//! ## Feature flags
+#![cfg_attr(
+    feature = "document-features",
+    cfg_attr(doc, doc = ::document_features::document_features!())
+)]
 
 #[cfg(feature = "hilog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "hilog")))]


### PR DESCRIPTION
Use the `document-features` crate to generate the feature documentation directly from the Cargo.toml