### PR TITLE
breaking: Consistently use newtype instead of moduleconsts for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.3.0 (unreleased)
+
+## Breaking
+
+- Change enum types in `native_buffer` and `native_window` to newtype pattern.
+
 # v0.2.2 (2024-08-18)
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ohos-sys"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Bindings to the native API of OpenHarmony OS"
 license = "Apache-2.0"

--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -108,7 +108,7 @@ bindgen "${BASE_BINDGEN_ARGS[@]}" \
 bindgen "${BASE_BINDGEN_ARGS[@]}" \
     --bitfield-enum 'OH_NativeBuffer_Usage' \
     --blocklist-item '_LIBCPP_.*' \
-    --default-enum-style=moduleconsts \
+    --default-enum-style=newtype \
     --no-copy '^OH_NativeBuffer$'  \
     --no-debug '^OH_NativeBuffer$'  \
     --output "${ROOT_DIR}/src/native_buffer/native_buffer_api${OHOS_API_VERSION}.rs" \
@@ -124,7 +124,7 @@ if [[ ${OHOS_API_VERSION} -eq 10 ]]; then
 fi
 
 bindgen "${BASE_BINDGEN_ARGS[@]}" \
-    --default-enum-style=moduleconsts \
+    --default-enum-style=newtype \
     --no-derive-copy \
     ${block_native_window_operation} \
     --output "${ROOT_DIR}/src/native_window/native_window_api${OHOS_API_VERSION}.rs" \

--- a/src/native_buffer/api11_additions.rs
+++ b/src/native_buffer/api11_additions.rs
@@ -4,78 +4,165 @@
 
 use super::OH_NativeBuffer;
 
-pub mod OH_NativeBuffer_ColorSpace {
-    /** @brief Indicates the color space of a native buffer.
-
-    @syscap SystemCapability.Graphic.Graphic2D.NativeBuffer
-    @since 11
-    @version 1.0*/
-    pub type Type = ::core::ffi::c_uint;
+impl OH_NativeBuffer_ColorSpace {
     /// None color space
-    pub const OH_COLORSPACE_NONE: Type = 0;
-    /// COLORPRIMARIES_BT601_P | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_P << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_BT601_EBU_FULL: Type = 1;
-    /// COLORPRIMARIES_BT601_N | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_N << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_BT601_SMPTE_C_FULL: Type = 2;
-    /// COLORPRIMARIES_BT709 | (TRANSFUNC_BT709 << 8) | (MATRIX_BT709 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_BT709_FULL: Type = 3;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_HLG << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_BT2020_HLG_FULL: Type = 4;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_PQ << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_BT2020_PQ_FULL: Type = 5;
-    /// COLORPRIMARIES_BT601_P | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_P << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_BT601_EBU_LIMIT: Type = 6;
-    /// COLORPRIMARIES_BT601_N | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_N << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_BT601_SMPTE_C_LIMIT: Type = 7;
-    /// COLORPRIMARIES_BT709 | (TRANSFUNC_BT709 << 8) | (MATRIX_BT709 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_BT709_LIMIT: Type = 8;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_HLG << 8) | (MATRIX_BT2020 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_BT2020_HLG_LIMIT: Type = 9;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_PQ << 8) | (MATRIX_BT2020 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_BT2020_PQ_LIMIT: Type = 10;
-    /// COLORPRIMARIES_SRGB | (TRANSFUNC_SRGB << 8) | (MATRIX_BT601_N << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_SRGB_FULL: Type = 11;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_SRGB << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_P3_FULL: Type = 12;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_HLG << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_P3_HLG_FULL: Type = 13;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_PQ << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_P3_PQ_FULL: Type = 14;
-    /// COLORPRIMARIES_ADOBERGB | (TRANSFUNC_ADOBERGB << 8) | (MATRIX_ADOBERGB << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_ADOBERGB_FULL: Type = 15;
-    /// COLORPRIMARIES_SRGB | (TRANSFUNC_SRGB << 8) | (MATRIX_BT601_N << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_SRGB_LIMIT: Type = 16;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_SRGB << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_P3_LIMIT: Type = 17;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_HLG << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_P3_HLG_LIMIT: Type = 18;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_PQ << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_P3_PQ_LIMIT: Type = 19;
-    /// COLORPRIMARIES_ADOBERGB | (TRANSFUNC_ADOBERGB << 8) | (MATRIX_ADOBERGB << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_ADOBERGB_LIMIT: Type = 20;
-    /// COLORPRIMARIES_SRGB | (TRANSFUNC_LINEAR << 8)
-    pub const OH_COLORSPACE_LINEAR_SRGB: Type = 21;
-    /// equal to OH_COLORSPACE_LINEAR_SRGB
-    pub const OH_COLORSPACE_LINEAR_BT709: Type = 22;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_LINEAR << 8)
-    pub const OH_COLORSPACE_LINEAR_P3: Type = 23;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_LINEAR << 8)
-    pub const OH_COLORSPACE_LINEAR_BT2020: Type = 24;
-    /// equal to OH_COLORSPACE_SRGB_FULL
-    pub const OH_COLORSPACE_DISPLAY_SRGB: Type = 25;
-    /// equal to OH_COLORSPACE_P3_FULL
-    pub const OH_COLORSPACE_DISPLAY_P3_SRGB: Type = 26;
-    /// equal to OH_COLORSPACE_P3_HLG_FULL
-    pub const OH_COLORSPACE_DISPLAY_P3_HLG: Type = 27;
-    /// equal to OH_COLORSPACE_P3_PQ_FULL
-    pub const OH_COLORSPACE_DISPLAY_P3_PQ: Type = 28;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_SRGB << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_DISPLAY_BT2020_SRGB: Type = 29;
-    /// equal to OH_COLORSPACE_BT2020_HLG_FULL
-    pub const OH_COLORSPACE_DISPLAY_BT2020_HLG: Type = 30;
-    /// equal to OH_COLORSPACE_BT2020_PQ_FULL
-    pub const OH_COLORSPACE_DISPLAY_BT2020_PQ: Type = 31;
+    pub const OH_COLORSPACE_NONE: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(0);
 }
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT601_P | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_P << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_BT601_EBU_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(1);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT601_N | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_N << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_BT601_SMPTE_C_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(2);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT709 | (TRANSFUNC_BT709 << 8) | (MATRIX_BT709 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_BT709_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(3);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_HLG << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_BT2020_HLG_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(4);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_PQ << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_BT2020_PQ_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(5);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT601_P | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_P << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_BT601_EBU_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(6);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT601_N | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_N << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_BT601_SMPTE_C_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(7);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT709 | (TRANSFUNC_BT709 << 8) | (MATRIX_BT709 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_BT709_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(8);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_HLG << 8) | (MATRIX_BT2020 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_BT2020_HLG_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(9);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_PQ << 8) | (MATRIX_BT2020 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_BT2020_PQ_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(10);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_SRGB | (TRANSFUNC_SRGB << 8) | (MATRIX_BT601_N << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_SRGB_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(11);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_SRGB << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_P3_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(12);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_HLG << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_P3_HLG_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(13);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_PQ << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_P3_PQ_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(14);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_ADOBERGB | (TRANSFUNC_ADOBERGB << 8) | (MATRIX_ADOBERGB << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_ADOBERGB_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(15);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_SRGB | (TRANSFUNC_SRGB << 8) | (MATRIX_BT601_N << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_SRGB_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(16);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_SRGB << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_P3_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(17);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_HLG << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_P3_HLG_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(18);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_PQ << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_P3_PQ_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(19);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_ADOBERGB | (TRANSFUNC_ADOBERGB << 8) | (MATRIX_ADOBERGB << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_ADOBERGB_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(20);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_SRGB | (TRANSFUNC_LINEAR << 8)
+    pub const OH_COLORSPACE_LINEAR_SRGB: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(21);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_LINEAR_SRGB
+    pub const OH_COLORSPACE_LINEAR_BT709: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(22);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_LINEAR << 8)
+    pub const OH_COLORSPACE_LINEAR_P3: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(23);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_LINEAR << 8)
+    pub const OH_COLORSPACE_LINEAR_BT2020: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(24);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_SRGB_FULL
+    pub const OH_COLORSPACE_DISPLAY_SRGB: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(25);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_P3_FULL
+    pub const OH_COLORSPACE_DISPLAY_P3_SRGB: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(26);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_P3_HLG_FULL
+    pub const OH_COLORSPACE_DISPLAY_P3_HLG: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(27);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_P3_PQ_FULL
+    pub const OH_COLORSPACE_DISPLAY_P3_PQ: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(28);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_SRGB << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_DISPLAY_BT2020_SRGB: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(29);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_BT2020_HLG_FULL
+    pub const OH_COLORSPACE_DISPLAY_BT2020_HLG: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(30);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_BT2020_PQ_FULL
+    pub const OH_COLORSPACE_DISPLAY_BT2020_PQ: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(31);
+}
+#[repr(transparent)]
+/** @brief Indicates the color space of a native buffer.
+
+@syscap SystemCapability.Graphic.Graphic2D.NativeBuffer
+@since 11
+@version 1.0*/
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct OH_NativeBuffer_ColorSpace(pub ::core::ffi::c_uint);
 
 extern "C" {
     /** @brief Set the color space of the OH_NativeBuffer.
@@ -88,6 +175,6 @@ extern "C" {
     @version 1.0*/
     pub fn OH_NativeBuffer_SetColorSpace(
         buffer: *mut OH_NativeBuffer,
-        colorSpace: OH_NativeBuffer_ColorSpace::Type,
+        colorSpace: OH_NativeBuffer_ColorSpace,
     ) -> i32;
 }

--- a/src/native_buffer/native_buffer_api10.rs
+++ b/src/native_buffer/native_buffer_api10.rs
@@ -53,51 +53,90 @@ impl ::core::ops::BitAndAssign for OH_NativeBuffer_Usage {
 @version 1.0*/
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct OH_NativeBuffer_Usage(pub ::core::ffi::c_uint);
-pub mod OH_NativeBuffer_Format {
-    /** @brief Indicates the format of a native buffer.
-
-    @syscap SystemCapability.Graphic.Graphic2D.NativeBuffer
-    @since 10
-    @version 1.0*/
-    pub type Type = ::core::ffi::c_uint;
-    pub const NATIVEBUFFER_PIXEL_FMT_RGB_565: Type = 3;
-    /// < RGB565 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_5658: Type = 4;
-    /// < RGBA5658 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_4444: Type = 5;
-    /// < RGBX4444 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_4444: Type = 6;
-    /// < RGBA4444 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGB_444: Type = 7;
-    /// < RGB444 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_5551: Type = 8;
-    /// < RGBX5551 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_5551: Type = 9;
-    /// < RGBA5551 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGB_555: Type = 10;
-    /// < RGB555 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_8888: Type = 11;
-    /// < RGBX8888 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_8888: Type = 12;
-    /// < RGBA8888 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGB_888: Type = 13;
-    /// < RGB888 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGR_565: Type = 14;
-    /// < BGR565 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_4444: Type = 15;
-    /// < BGRX4444 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_4444: Type = 16;
-    /// < BGRA4444 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_5551: Type = 17;
-    /// < BGRX5551 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_5551: Type = 18;
-    /// < BGRA5551 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_8888: Type = 19;
-    /// < BGRX8888 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_8888: Type = 20;
-    /// < BGRA8888 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BUTT: Type = 2147483647;
+impl OH_NativeBuffer_Format {
+    pub const NATIVEBUFFER_PIXEL_FMT_RGB_565: OH_NativeBuffer_Format = OH_NativeBuffer_Format(3);
 }
+impl OH_NativeBuffer_Format {
+    /// < RGB565 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_5658: OH_NativeBuffer_Format = OH_NativeBuffer_Format(4);
+}
+impl OH_NativeBuffer_Format {
+    /// < RGBA5658 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(5);
+}
+impl OH_NativeBuffer_Format {
+    /// < RGBX4444 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(6);
+}
+impl OH_NativeBuffer_Format {
+    /// < RGBA4444 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_RGB_444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(7);
+}
+impl OH_NativeBuffer_Format {
+    /// < RGB444 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(8);
+}
+impl OH_NativeBuffer_Format {
+    /// < RGBX5551 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(9);
+}
+impl OH_NativeBuffer_Format {
+    /// < RGBA5551 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_RGB_555: OH_NativeBuffer_Format = OH_NativeBuffer_Format(10);
+}
+impl OH_NativeBuffer_Format {
+    /// < RGB555 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(11);
+}
+impl OH_NativeBuffer_Format {
+    /// < RGBX8888 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(12);
+}
+impl OH_NativeBuffer_Format {
+    /// < RGBA8888 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_RGB_888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(13);
+}
+impl OH_NativeBuffer_Format {
+    /// < RGB888 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_BGR_565: OH_NativeBuffer_Format = OH_NativeBuffer_Format(14);
+}
+impl OH_NativeBuffer_Format {
+    /// < BGR565 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(15);
+}
+impl OH_NativeBuffer_Format {
+    /// < BGRX4444 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(16);
+}
+impl OH_NativeBuffer_Format {
+    /// < BGRA4444 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(17);
+}
+impl OH_NativeBuffer_Format {
+    /// < BGRX5551 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(18);
+}
+impl OH_NativeBuffer_Format {
+    /// < BGRA5551 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(19);
+}
+impl OH_NativeBuffer_Format {
+    /// < BGRX8888 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(20);
+}
+impl OH_NativeBuffer_Format {
+    /// < BGRA8888 format */
+    pub const NATIVEBUFFER_PIXEL_FMT_BUTT: OH_NativeBuffer_Format =
+        OH_NativeBuffer_Format(2147483647);
+}
+#[repr(transparent)]
+/** @brief Indicates the format of a native buffer.
+
+@syscap SystemCapability.Graphic.Graphic2D.NativeBuffer
+@since 10
+@version 1.0*/
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct OH_NativeBuffer_Format(pub ::core::ffi::c_uint);
 /** @brief <b>OH_NativeBuffer</b> config. \n
 Used to allocating new <b>OH_NativeBuffer</b> andquery parameters if existing ones.
 

--- a/src/native_buffer/native_buffer_api11.rs
+++ b/src/native_buffer/native_buffer_api11.rs
@@ -53,123 +53,249 @@ impl ::core::ops::BitAndAssign for OH_NativeBuffer_Usage {
 @version 1.0*/
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct OH_NativeBuffer_Usage(pub ::core::ffi::c_uint);
-pub mod OH_NativeBuffer_Format {
-    /** @brief Indicates the format of a native buffer.
-
-    @syscap SystemCapability.Graphic.Graphic2D.NativeBuffer
-    @since 10
-    @version 1.0*/
-    pub type Type = ::core::ffi::c_uint;
-    pub const NATIVEBUFFER_PIXEL_FMT_RGB_565: Type = 3;
+impl OH_NativeBuffer_Format {
+    pub const NATIVEBUFFER_PIXEL_FMT_RGB_565: OH_NativeBuffer_Format = OH_NativeBuffer_Format(3);
+}
+impl OH_NativeBuffer_Format {
     /// < RGB565 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_5658: Type = 4;
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_5658: OH_NativeBuffer_Format = OH_NativeBuffer_Format(4);
+}
+impl OH_NativeBuffer_Format {
     /// < RGBA5658 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_4444: Type = 5;
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(5);
+}
+impl OH_NativeBuffer_Format {
     /// < RGBX4444 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_4444: Type = 6;
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(6);
+}
+impl OH_NativeBuffer_Format {
     /// < RGBA4444 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGB_444: Type = 7;
+    pub const NATIVEBUFFER_PIXEL_FMT_RGB_444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(7);
+}
+impl OH_NativeBuffer_Format {
     /// < RGB444 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_5551: Type = 8;
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(8);
+}
+impl OH_NativeBuffer_Format {
     /// < RGBX5551 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_5551: Type = 9;
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(9);
+}
+impl OH_NativeBuffer_Format {
     /// < RGBA5551 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGB_555: Type = 10;
+    pub const NATIVEBUFFER_PIXEL_FMT_RGB_555: OH_NativeBuffer_Format = OH_NativeBuffer_Format(10);
+}
+impl OH_NativeBuffer_Format {
     /// < RGB555 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_8888: Type = 11;
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBX_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(11);
+}
+impl OH_NativeBuffer_Format {
     /// < RGBX8888 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_8888: Type = 12;
+    pub const NATIVEBUFFER_PIXEL_FMT_RGBA_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(12);
+}
+impl OH_NativeBuffer_Format {
     /// < RGBA8888 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_RGB_888: Type = 13;
+    pub const NATIVEBUFFER_PIXEL_FMT_RGB_888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(13);
+}
+impl OH_NativeBuffer_Format {
     /// < RGB888 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGR_565: Type = 14;
+    pub const NATIVEBUFFER_PIXEL_FMT_BGR_565: OH_NativeBuffer_Format = OH_NativeBuffer_Format(14);
+}
+impl OH_NativeBuffer_Format {
     /// < BGR565 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_4444: Type = 15;
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(15);
+}
+impl OH_NativeBuffer_Format {
     /// < BGRX4444 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_4444: Type = 16;
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(16);
+}
+impl OH_NativeBuffer_Format {
     /// < BGRA4444 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_5551: Type = 17;
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(17);
+}
+impl OH_NativeBuffer_Format {
     /// < BGRX5551 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_5551: Type = 18;
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(18);
+}
+impl OH_NativeBuffer_Format {
     /// < BGRA5551 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_8888: Type = 19;
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRX_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(19);
+}
+impl OH_NativeBuffer_Format {
     /// < BGRX8888 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_8888: Type = 20;
+    pub const NATIVEBUFFER_PIXEL_FMT_BGRA_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(20);
+}
+impl OH_NativeBuffer_Format {
     /// < BGRA8888 format */
-    pub const NATIVEBUFFER_PIXEL_FMT_BUTT: Type = 2147483647;
+    pub const NATIVEBUFFER_PIXEL_FMT_BUTT: OH_NativeBuffer_Format =
+        OH_NativeBuffer_Format(2147483647);
 }
-pub mod OH_NativeBuffer_ColorSpace {
-    /** @brief Indicates the color space of a native buffer.
+#[repr(transparent)]
+/** @brief Indicates the format of a native buffer.
 
-    @syscap SystemCapability.Graphic.Graphic2D.NativeBuffer
-    @since 11
-    @version 1.0*/
-    pub type Type = ::core::ffi::c_uint;
+@syscap SystemCapability.Graphic.Graphic2D.NativeBuffer
+@since 10
+@version 1.0*/
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct OH_NativeBuffer_Format(pub ::core::ffi::c_uint);
+impl OH_NativeBuffer_ColorSpace {
     /// None color space
-    pub const OH_COLORSPACE_NONE: Type = 0;
-    /// COLORPRIMARIES_BT601_P | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_P << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_BT601_EBU_FULL: Type = 1;
-    /// COLORPRIMARIES_BT601_N | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_N << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_BT601_SMPTE_C_FULL: Type = 2;
-    /// COLORPRIMARIES_BT709 | (TRANSFUNC_BT709 << 8) | (MATRIX_BT709 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_BT709_FULL: Type = 3;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_HLG << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_BT2020_HLG_FULL: Type = 4;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_PQ << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_BT2020_PQ_FULL: Type = 5;
-    /// COLORPRIMARIES_BT601_P | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_P << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_BT601_EBU_LIMIT: Type = 6;
-    /// COLORPRIMARIES_BT601_N | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_N << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_BT601_SMPTE_C_LIMIT: Type = 7;
-    /// COLORPRIMARIES_BT709 | (TRANSFUNC_BT709 << 8) | (MATRIX_BT709 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_BT709_LIMIT: Type = 8;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_HLG << 8) | (MATRIX_BT2020 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_BT2020_HLG_LIMIT: Type = 9;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_PQ << 8) | (MATRIX_BT2020 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_BT2020_PQ_LIMIT: Type = 10;
-    /// COLORPRIMARIES_SRGB | (TRANSFUNC_SRGB << 8) | (MATRIX_BT601_N << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_SRGB_FULL: Type = 11;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_SRGB << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_P3_FULL: Type = 12;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_HLG << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_P3_HLG_FULL: Type = 13;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_PQ << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_P3_PQ_FULL: Type = 14;
-    /// COLORPRIMARIES_ADOBERGB | (TRANSFUNC_ADOBERGB << 8) | (MATRIX_ADOBERGB << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_ADOBERGB_FULL: Type = 15;
-    /// COLORPRIMARIES_SRGB | (TRANSFUNC_SRGB << 8) | (MATRIX_BT601_N << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_SRGB_LIMIT: Type = 16;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_SRGB << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_P3_LIMIT: Type = 17;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_HLG << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_P3_HLG_LIMIT: Type = 18;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_PQ << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_P3_PQ_LIMIT: Type = 19;
-    /// COLORPRIMARIES_ADOBERGB | (TRANSFUNC_ADOBERGB << 8) | (MATRIX_ADOBERGB << 16) | (RANGE_LIMITED << 21)
-    pub const OH_COLORSPACE_ADOBERGB_LIMIT: Type = 20;
-    /// COLORPRIMARIES_SRGB | (TRANSFUNC_LINEAR << 8)
-    pub const OH_COLORSPACE_LINEAR_SRGB: Type = 21;
-    /// equal to OH_COLORSPACE_LINEAR_SRGB
-    pub const OH_COLORSPACE_LINEAR_BT709: Type = 22;
-    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_LINEAR << 8)
-    pub const OH_COLORSPACE_LINEAR_P3: Type = 23;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_LINEAR << 8)
-    pub const OH_COLORSPACE_LINEAR_BT2020: Type = 24;
-    /// equal to OH_COLORSPACE_SRGB_FULL
-    pub const OH_COLORSPACE_DISPLAY_SRGB: Type = 25;
-    /// equal to OH_COLORSPACE_P3_FULL
-    pub const OH_COLORSPACE_DISPLAY_P3_SRGB: Type = 26;
-    /// equal to OH_COLORSPACE_P3_HLG_FULL
-    pub const OH_COLORSPACE_DISPLAY_P3_HLG: Type = 27;
-    /// equal to OH_COLORSPACE_P3_PQ_FULL
-    pub const OH_COLORSPACE_DISPLAY_P3_PQ: Type = 28;
-    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_SRGB << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
-    pub const OH_COLORSPACE_DISPLAY_BT2020_SRGB: Type = 29;
-    /// equal to OH_COLORSPACE_BT2020_HLG_FULL
-    pub const OH_COLORSPACE_DISPLAY_BT2020_HLG: Type = 30;
-    /// equal to OH_COLORSPACE_BT2020_PQ_FULL
-    pub const OH_COLORSPACE_DISPLAY_BT2020_PQ: Type = 31;
+    pub const OH_COLORSPACE_NONE: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(0);
 }
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT601_P | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_P << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_BT601_EBU_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(1);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT601_N | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_N << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_BT601_SMPTE_C_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(2);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT709 | (TRANSFUNC_BT709 << 8) | (MATRIX_BT709 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_BT709_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(3);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_HLG << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_BT2020_HLG_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(4);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_PQ << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_BT2020_PQ_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(5);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT601_P | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_P << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_BT601_EBU_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(6);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT601_N | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_N << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_BT601_SMPTE_C_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(7);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT709 | (TRANSFUNC_BT709 << 8) | (MATRIX_BT709 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_BT709_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(8);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_HLG << 8) | (MATRIX_BT2020 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_BT2020_HLG_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(9);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_PQ << 8) | (MATRIX_BT2020 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_BT2020_PQ_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(10);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_SRGB | (TRANSFUNC_SRGB << 8) | (MATRIX_BT601_N << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_SRGB_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(11);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_SRGB << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_P3_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(12);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_HLG << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_P3_HLG_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(13);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_PQ << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_P3_PQ_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(14);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_ADOBERGB | (TRANSFUNC_ADOBERGB << 8) | (MATRIX_ADOBERGB << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_ADOBERGB_FULL: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(15);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_SRGB | (TRANSFUNC_SRGB << 8) | (MATRIX_BT601_N << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_SRGB_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(16);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_SRGB << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_P3_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(17);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_HLG << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_P3_HLG_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(18);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_PQ << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_P3_PQ_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(19);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_ADOBERGB | (TRANSFUNC_ADOBERGB << 8) | (MATRIX_ADOBERGB << 16) | (RANGE_LIMITED << 21)
+    pub const OH_COLORSPACE_ADOBERGB_LIMIT: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(20);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_SRGB | (TRANSFUNC_LINEAR << 8)
+    pub const OH_COLORSPACE_LINEAR_SRGB: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(21);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_LINEAR_SRGB
+    pub const OH_COLORSPACE_LINEAR_BT709: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(22);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_LINEAR << 8)
+    pub const OH_COLORSPACE_LINEAR_P3: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(23);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_LINEAR << 8)
+    pub const OH_COLORSPACE_LINEAR_BT2020: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(24);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_SRGB_FULL
+    pub const OH_COLORSPACE_DISPLAY_SRGB: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(25);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_P3_FULL
+    pub const OH_COLORSPACE_DISPLAY_P3_SRGB: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(26);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_P3_HLG_FULL
+    pub const OH_COLORSPACE_DISPLAY_P3_HLG: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(27);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_P3_PQ_FULL
+    pub const OH_COLORSPACE_DISPLAY_P3_PQ: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(28);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// COLORPRIMARIES_BT2020 | (TRANSFUNC_SRGB << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
+    pub const OH_COLORSPACE_DISPLAY_BT2020_SRGB: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(29);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_BT2020_HLG_FULL
+    pub const OH_COLORSPACE_DISPLAY_BT2020_HLG: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(30);
+}
+impl OH_NativeBuffer_ColorSpace {
+    /// equal to OH_COLORSPACE_BT2020_PQ_FULL
+    pub const OH_COLORSPACE_DISPLAY_BT2020_PQ: OH_NativeBuffer_ColorSpace =
+        OH_NativeBuffer_ColorSpace(31);
+}
+#[repr(transparent)]
+/** @brief Indicates the color space of a native buffer.
+
+@syscap SystemCapability.Graphic.Graphic2D.NativeBuffer
+@since 11
+@version 1.0*/
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct OH_NativeBuffer_ColorSpace(pub ::core::ffi::c_uint);
 /** @brief <b>OH_NativeBuffer</b> config. \n
 Used to allocating new <b>OH_NativeBuffer</b> andquery parameters if existing ones.
 
@@ -268,6 +394,6 @@ extern "C" {
     @version 1.0*/
     pub fn OH_NativeBuffer_SetColorSpace(
         buffer: *mut OH_NativeBuffer,
-        colorSpace: OH_NativeBuffer_ColorSpace::Type,
+        colorSpace: OH_NativeBuffer_ColorSpace,
     ) -> i32;
 }

--- a/src/native_window/native_window_api10.rs
+++ b/src/native_window/native_window_api10.rs
@@ -101,50 +101,86 @@ pub struct Region_Rect {
     pub w: u32,
     pub h: u32,
 }
-pub mod OHScalingMode {
-    /** @brief Indicates Scaling Mode.
-    @since 9
-    @deprecated(since = "10")*/
-    pub type Type = ::core::ffi::c_uint;
+impl OHScalingMode {
     /** the window content is not updated until a buffer of
     the window size is received*/
-    pub const OH_SCALING_MODE_FREEZE: Type = 0;
+    pub const OH_SCALING_MODE_FREEZE: OHScalingMode = OHScalingMode(0);
+}
+impl OHScalingMode {
     /// the buffer is scaled in two dimensions to match the window size
-    pub const OH_SCALING_MODE_SCALE_TO_WINDOW: Type = 1;
+    pub const OH_SCALING_MODE_SCALE_TO_WINDOW: OHScalingMode = OHScalingMode(1);
+}
+impl OHScalingMode {
     /** the buffer is uniformly scaled so that the smaller size of
     the buffer matches the window size*/
-    pub const OH_SCALING_MODE_SCALE_CROP: Type = 2;
+    pub const OH_SCALING_MODE_SCALE_CROP: OHScalingMode = OHScalingMode(2);
+}
+impl OHScalingMode {
     /** the window is clipped to the size of the buffer's clipping rectangle
     pixels outside the clipping rectangle are considered fully transparent.*/
-    pub const OH_SCALING_MODE_NO_SCALE_CROP: Type = 3;
+    pub const OH_SCALING_MODE_NO_SCALE_CROP: OHScalingMode = OHScalingMode(3);
 }
-pub mod OHHDRMetadataKey {
-    /** @brief Enumerates the HDR metadata keys.
-    @since 9
-    @deprecated(since = "10")*/
-    pub type Type = ::core::ffi::c_uint;
-    pub const OH_METAKEY_RED_PRIMARY_X: Type = 0;
-    pub const OH_METAKEY_RED_PRIMARY_Y: Type = 1;
-    pub const OH_METAKEY_GREEN_PRIMARY_X: Type = 2;
-    pub const OH_METAKEY_GREEN_PRIMARY_Y: Type = 3;
-    pub const OH_METAKEY_BLUE_PRIMARY_X: Type = 4;
-    pub const OH_METAKEY_BLUE_PRIMARY_Y: Type = 5;
-    pub const OH_METAKEY_WHITE_PRIMARY_X: Type = 6;
-    pub const OH_METAKEY_WHITE_PRIMARY_Y: Type = 7;
-    pub const OH_METAKEY_MAX_LUMINANCE: Type = 8;
-    pub const OH_METAKEY_MIN_LUMINANCE: Type = 9;
-    pub const OH_METAKEY_MAX_CONTENT_LIGHT_LEVEL: Type = 10;
-    pub const OH_METAKEY_MAX_FRAME_AVERAGE_LIGHT_LEVEL: Type = 11;
-    pub const OH_METAKEY_HDR10_PLUS: Type = 12;
-    pub const OH_METAKEY_HDR_VIVID: Type = 13;
+#[repr(transparent)]
+/** @brief Indicates Scaling Mode.
+@since 9
+@deprecated(since = "10")*/
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct OHScalingMode(pub ::core::ffi::c_uint);
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_RED_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(0);
 }
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_RED_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(1);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_GREEN_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(2);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_GREEN_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(3);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_BLUE_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(4);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_BLUE_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(5);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_WHITE_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(6);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_WHITE_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(7);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_MAX_LUMINANCE: OHHDRMetadataKey = OHHDRMetadataKey(8);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_MIN_LUMINANCE: OHHDRMetadataKey = OHHDRMetadataKey(9);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_MAX_CONTENT_LIGHT_LEVEL: OHHDRMetadataKey = OHHDRMetadataKey(10);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_MAX_FRAME_AVERAGE_LIGHT_LEVEL: OHHDRMetadataKey = OHHDRMetadataKey(11);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_HDR10_PLUS: OHHDRMetadataKey = OHHDRMetadataKey(12);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_HDR_VIVID: OHHDRMetadataKey = OHHDRMetadataKey(13);
+}
+#[repr(transparent)]
+/** @brief Enumerates the HDR metadata keys.
+@since 9
+@deprecated(since = "10")*/
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct OHHDRMetadataKey(pub ::core::ffi::c_uint);
 /** @brief Defines the HDR metadata.
 @since 9
 @deprecated(since = "10")*/
 #[repr(C)]
 #[derive(Debug)]
 pub struct OHHDRMetaData {
-    pub key: OHHDRMetadataKey::Type,
+    pub key: OHHDRMetadataKey,
     pub value: f32,
 }
 /** @brief Defines the ExtData Handle
@@ -295,7 +331,7 @@ extern "C" {
     pub fn OH_NativeWindow_NativeWindowSetScalingMode(
         window: *mut OHNativeWindow,
         sequence: u32,
-        scalingMode: OHScalingMode::Type,
+        scalingMode: OHScalingMode,
     ) -> i32;
     /** @brief Sets metaData of a native window.
 
@@ -329,7 +365,7 @@ extern "C" {
     pub fn OH_NativeWindow_NativeWindowSetMetaDataSet(
         window: *mut OHNativeWindow,
         sequence: u32,
-        key: OHHDRMetadataKey::Type,
+        key: OHHDRMetadataKey,
         size: i32,
         metaData: *const u8,
     ) -> i32;

--- a/src/native_window/native_window_api11.rs
+++ b/src/native_window/native_window_api11.rs
@@ -106,123 +106,193 @@ pub struct Region_Rect {
     pub w: u32,
     pub h: u32,
 }
-pub mod NativeWindowOperation {
-    /** @brief Indicates the operation code in the function OH_NativeWindow_NativeWindowHandleOpt.
-    @since 8*/
-    pub type Type = ::core::ffi::c_uint;
+impl NativeWindowOperation {
     /** set native window buffer geometry,
     variable parameter in function is
     [in] int32_t width, [in] int32_t height*/
-    pub const SET_BUFFER_GEOMETRY: Type = 0;
+    pub const SET_BUFFER_GEOMETRY: NativeWindowOperation = NativeWindowOperation(0);
+}
+impl NativeWindowOperation {
     /** get native window buffer geometry,
     variable parameter in function is
     [out] int32_t *height, [out] int32_t *width*/
-    pub const GET_BUFFER_GEOMETRY: Type = 1;
+    pub const GET_BUFFER_GEOMETRY: NativeWindowOperation = NativeWindowOperation(1);
+}
+impl NativeWindowOperation {
     /** get native window buffer format,
     variable parameter in function is
     [out] int32_t *format*/
-    pub const GET_FORMAT: Type = 2;
+    pub const GET_FORMAT: NativeWindowOperation = NativeWindowOperation(2);
+}
+impl NativeWindowOperation {
     /** set native window buffer format,
     variable parameter in function is
     [in] int32_t format*/
-    pub const SET_FORMAT: Type = 3;
+    pub const SET_FORMAT: NativeWindowOperation = NativeWindowOperation(3);
+}
+impl NativeWindowOperation {
     /** get native window buffer usage,
     variable parameter in function is
     [out] int32_t *usage.*/
-    pub const GET_USAGE: Type = 4;
+    pub const GET_USAGE: NativeWindowOperation = NativeWindowOperation(4);
+}
+impl NativeWindowOperation {
     /** set native window buffer usage,
     variable parameter in function is
     [in] int32_t usage.*/
-    pub const SET_USAGE: Type = 5;
+    pub const SET_USAGE: NativeWindowOperation = NativeWindowOperation(5);
+}
+impl NativeWindowOperation {
     /** set native window buffer stride,
     variable parameter in function is
     [in] int32_t stride.*/
-    pub const SET_STRIDE: Type = 6;
+    pub const SET_STRIDE: NativeWindowOperation = NativeWindowOperation(6);
+}
+impl NativeWindowOperation {
     /** get native window buffer stride,
     variable parameter in function is
     [out] int32_t *stride.*/
-    pub const GET_STRIDE: Type = 7;
+    pub const GET_STRIDE: NativeWindowOperation = NativeWindowOperation(7);
+}
+impl NativeWindowOperation {
     /** set native window buffer swap interval,
     variable parameter in function is
     [in] int32_t interval.*/
-    pub const SET_SWAP_INTERVAL: Type = 8;
+    pub const SET_SWAP_INTERVAL: NativeWindowOperation = NativeWindowOperation(8);
+}
+impl NativeWindowOperation {
     /** get native window buffer swap interval,
     variable parameter in function is
     [out] int32_t *interval.*/
-    pub const GET_SWAP_INTERVAL: Type = 9;
+    pub const GET_SWAP_INTERVAL: NativeWindowOperation = NativeWindowOperation(9);
+}
+impl NativeWindowOperation {
     /** set native window buffer timeout,
     variable parameter in function is
     [in] int32_t timeout.*/
-    pub const SET_TIMEOUT: Type = 10;
+    pub const SET_TIMEOUT: NativeWindowOperation = NativeWindowOperation(10);
+}
+impl NativeWindowOperation {
     /** get native window buffer timeout,
     variable parameter in function is
     [out] int32_t *timeout.*/
-    pub const GET_TIMEOUT: Type = 11;
+    pub const GET_TIMEOUT: NativeWindowOperation = NativeWindowOperation(11);
+}
+impl NativeWindowOperation {
     /** set native window buffer colorGamut,
     variable parameter in function is
     [in] int32_t colorGamut.*/
-    pub const SET_COLOR_GAMUT: Type = 12;
+    pub const SET_COLOR_GAMUT: NativeWindowOperation = NativeWindowOperation(12);
+}
+impl NativeWindowOperation {
     /** get native window buffer colorGamut,
     variable parameter in function is
     [out int32_t *colorGamut].*/
-    pub const GET_COLOR_GAMUT: Type = 13;
+    pub const GET_COLOR_GAMUT: NativeWindowOperation = NativeWindowOperation(13);
+}
+impl NativeWindowOperation {
     /** set native window buffer transform,
     variable parameter in function is
     [in] int32_t transform.*/
-    pub const SET_TRANSFORM: Type = 14;
+    pub const SET_TRANSFORM: NativeWindowOperation = NativeWindowOperation(14);
+}
+impl NativeWindowOperation {
     /** get native window buffer transform,
     variable parameter in function is
     [out] int32_t *transform.*/
-    pub const GET_TRANSFORM: Type = 15;
+    pub const GET_TRANSFORM: NativeWindowOperation = NativeWindowOperation(15);
+}
+impl NativeWindowOperation {
     /** set native window buffer uiTimestamp,
     variable parameter in function is
     [in] uint64_t uiTimestamp.*/
-    pub const SET_UI_TIMESTAMP: Type = 16;
+    pub const SET_UI_TIMESTAMP: NativeWindowOperation = NativeWindowOperation(16);
 }
-pub mod OHScalingMode {
-    /** @brief Indicates Scaling Mode.
-    @since 9
-    @deprecated(since = "10")*/
-    pub type Type = ::core::ffi::c_uint;
+#[repr(transparent)]
+/** @brief Indicates the operation code in the function OH_NativeWindow_NativeWindowHandleOpt.
+@since 8*/
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct NativeWindowOperation(pub ::core::ffi::c_uint);
+impl OHScalingMode {
     /** the window content is not updated until a buffer of
     the window size is received*/
-    pub const OH_SCALING_MODE_FREEZE: Type = 0;
+    pub const OH_SCALING_MODE_FREEZE: OHScalingMode = OHScalingMode(0);
+}
+impl OHScalingMode {
     /// the buffer is scaled in two dimensions to match the window size
-    pub const OH_SCALING_MODE_SCALE_TO_WINDOW: Type = 1;
+    pub const OH_SCALING_MODE_SCALE_TO_WINDOW: OHScalingMode = OHScalingMode(1);
+}
+impl OHScalingMode {
     /** the buffer is uniformly scaled so that the smaller size of
     the buffer matches the window size*/
-    pub const OH_SCALING_MODE_SCALE_CROP: Type = 2;
+    pub const OH_SCALING_MODE_SCALE_CROP: OHScalingMode = OHScalingMode(2);
+}
+impl OHScalingMode {
     /** the window is clipped to the size of the buffer's clipping rectangle
     pixels outside the clipping rectangle are considered fully transparent.*/
-    pub const OH_SCALING_MODE_NO_SCALE_CROP: Type = 3;
+    pub const OH_SCALING_MODE_NO_SCALE_CROP: OHScalingMode = OHScalingMode(3);
 }
-pub mod OHHDRMetadataKey {
-    /** @brief Enumerates the HDR metadata keys.
-    @since 9
-    @deprecated(since = "10")*/
-    pub type Type = ::core::ffi::c_uint;
-    pub const OH_METAKEY_RED_PRIMARY_X: Type = 0;
-    pub const OH_METAKEY_RED_PRIMARY_Y: Type = 1;
-    pub const OH_METAKEY_GREEN_PRIMARY_X: Type = 2;
-    pub const OH_METAKEY_GREEN_PRIMARY_Y: Type = 3;
-    pub const OH_METAKEY_BLUE_PRIMARY_X: Type = 4;
-    pub const OH_METAKEY_BLUE_PRIMARY_Y: Type = 5;
-    pub const OH_METAKEY_WHITE_PRIMARY_X: Type = 6;
-    pub const OH_METAKEY_WHITE_PRIMARY_Y: Type = 7;
-    pub const OH_METAKEY_MAX_LUMINANCE: Type = 8;
-    pub const OH_METAKEY_MIN_LUMINANCE: Type = 9;
-    pub const OH_METAKEY_MAX_CONTENT_LIGHT_LEVEL: Type = 10;
-    pub const OH_METAKEY_MAX_FRAME_AVERAGE_LIGHT_LEVEL: Type = 11;
-    pub const OH_METAKEY_HDR10_PLUS: Type = 12;
-    pub const OH_METAKEY_HDR_VIVID: Type = 13;
+#[repr(transparent)]
+/** @brief Indicates Scaling Mode.
+@since 9
+@deprecated(since = "10")*/
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct OHScalingMode(pub ::core::ffi::c_uint);
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_RED_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(0);
 }
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_RED_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(1);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_GREEN_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(2);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_GREEN_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(3);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_BLUE_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(4);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_BLUE_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(5);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_WHITE_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(6);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_WHITE_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(7);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_MAX_LUMINANCE: OHHDRMetadataKey = OHHDRMetadataKey(8);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_MIN_LUMINANCE: OHHDRMetadataKey = OHHDRMetadataKey(9);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_MAX_CONTENT_LIGHT_LEVEL: OHHDRMetadataKey = OHHDRMetadataKey(10);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_MAX_FRAME_AVERAGE_LIGHT_LEVEL: OHHDRMetadataKey = OHHDRMetadataKey(11);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_HDR10_PLUS: OHHDRMetadataKey = OHHDRMetadataKey(12);
+}
+impl OHHDRMetadataKey {
+    pub const OH_METAKEY_HDR_VIVID: OHHDRMetadataKey = OHHDRMetadataKey(13);
+}
+#[repr(transparent)]
+/** @brief Enumerates the HDR metadata keys.
+@since 9
+@deprecated(since = "10")*/
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct OHHDRMetadataKey(pub ::core::ffi::c_uint);
 /** @brief Defines the HDR metadata.
 @since 9
 @deprecated(since = "10")*/
 #[repr(C)]
 #[derive(Debug)]
 pub struct OHHDRMetaData {
-    pub key: OHHDRMetadataKey::Type,
+    pub key: OHHDRMetadataKey,
     pub value: f32,
 }
 /** @brief Defines the ExtData Handle
@@ -400,7 +470,7 @@ extern "C" {
     pub fn OH_NativeWindow_NativeWindowSetScalingMode(
         window: *mut OHNativeWindow,
         sequence: u32,
-        scalingMode: OHScalingMode::Type,
+        scalingMode: OHScalingMode,
     ) -> i32;
     /** @brief Sets metaData of a native window.
 
@@ -434,7 +504,7 @@ extern "C" {
     pub fn OH_NativeWindow_NativeWindowSetMetaDataSet(
         window: *mut OHNativeWindow,
         sequence: u32,
-        key: OHHDRMetadataKey::Type,
+        key: OHHDRMetadataKey,
         size: i32,
         metaData: *const u8,
     ) -> i32;


### PR DESCRIPTION
This makes adding more variants from other files easier