### PR TITLE
Bump ohos-sys to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "ohos-sys"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "document-features",
  "hilog-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ohos-sys"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "Bindings to the native API of OpenHarmony OS"
 license = "Apache-2.0"


### PR DESCRIPTION
The previous commit somehow didn't include the version bump.