### PR TITLE
ci: Remove semver-checks from required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - build-toolchains
       - api_feature_levels
       - api_minimal_featueres
-      - semver_checks
+      # - semver_checks
       - rustdoc
     steps:
       - name: Success


### PR DESCRIPTION
There are a false positives when moving an item to a new crate, and re-exporting the item again via
`pub use`.
We just settle for manually checking the results before publishing and accept semver checks can report
errors