### PR TITLE
Re-export rawfile, image-kit and multimodal input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
   api_feature_levels:
     strategy:
       matrix:
-        api_level: ["api-10", "api-11", "api-12", "api-13"]
+        api_level: ["api-10", "api-11", "api-12", "api-13", "api-14"]
     name: Build with API feature levels
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +44,22 @@ jobs:
   api_minimal_featueres:
     strategy:
       matrix:
-        component: ["drawing", "hilog", "napi", "hitrace", "native_buffer", "native_image", "native_window", "xcomponent", "vsync"]
+        component:
+          - arkui
+          - deviceinfo
+          - drawing
+          - hilog
+          - hitrace
+          - inputmethod
+          - image-kit
+          - multimodal-input
+          - napi
+          - native_buffer
+          - native_image
+          - native_window
+          - rawfile
+          - vsync
+          - xcomponent
     name: Build with minimal features
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "ohos-sys"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "arkui-sys",
  "document-features",
@@ -122,6 +122,8 @@ dependencies = [
  "ohos-drawing-sys",
  "ohos-image-kit-sys",
  "ohos-ime-sys",
+ "ohos-input-sys",
+ "ohos-rawfile-sys",
  "ohos-sys-opaque-types",
  "ohos-vsync-sys",
  "xcomponent-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,19 +19,19 @@ ohos-sys-opaque-types = { version = "0.1.4", path = "components/opaque-types" }
 
 
 [dependencies]
-arkui-sys = { version = "0.2.2", optional = true, path = "components/arkui" }
+arkui-sys = { version = "0.2.4", optional = true, path = "components/arkui" }
 document-features = { version = "0.2", optional = true }
 hilog-sys = { version = "0.1.4", optional = true, path = "components/hilog"}
 hitrace-sys = { version = "0.1.4", optional = true, path = "components/hitrace"}
 ohos-deviceinfo-sys = { version = "0.1.2", optional = true, path = "components/deviceinfo"}
-ohos-drawing-sys = { path = "components/drawing", version = "0.2.1", optional = true}
+ohos-drawing-sys = { path = "components/drawing", version = "0.2.2", optional = true}
 ohos-image-kit-sys = {version = "0.2", optional = true, path = "components/multimedia/image_framework"}
-ohos-ime-sys = { version = "0.1.3", optional = true, path = "components/inputmethod"}
+ohos-ime-sys = { version = "0.1.4", optional = true, path = "components/inputmethod"}
 ohos-input-sys = { version = "0.1.1", optional = true, path  = "components/multimodal-input"}
 ohos-rawfile-sys = { version = "0.1.0", optional = true, path = "components/rawfile"}
 ohos-sys-opaque-types = { workspace = true}
-ohos-vsync-sys = { version = "0.1.1", optional = true, path = "components/vsync"}
-xcomponent-sys = {version = "0.3.0", optional = true, path = "components/xcomponent"}
+ohos-vsync-sys = { version = "0.1.2", optional = true, path = "components/vsync"}
+xcomponent-sys = {version = "0.3.1", optional = true, path = "components/xcomponent"}
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ohos-sys"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Bindings to the native API of OpenHarmony OS"
 license = "Apache-2.0"
@@ -21,15 +21,17 @@ ohos-sys-opaque-types = { version = "0.1.4", path = "components/opaque-types" }
 [dependencies]
 arkui-sys = { version = "0.2.2", optional = true, path = "components/arkui" }
 document-features = { version = "0.2", optional = true }
-ohos-drawing-sys = { path = "components/drawing", version = "0.2.1", optional = true}
-ohos-deviceinfo-sys = { version = "0.1.2", optional = true, path = "components/deviceinfo"}
-hitrace-sys = { version = "0.1.4", optional = true, path = "components/hitrace"}
-ohos-ime-sys = { version = "0.1.3", optional = true, path = "components/inputmethod"}
 hilog-sys = { version = "0.1.4", optional = true, path = "components/hilog"}
-xcomponent-sys = {version = "0.3.0", optional = true, path = "components/xcomponent"}
+hitrace-sys = { version = "0.1.4", optional = true, path = "components/hitrace"}
+ohos-deviceinfo-sys = { version = "0.1.2", optional = true, path = "components/deviceinfo"}
+ohos-drawing-sys = { path = "components/drawing", version = "0.2.1", optional = true}
 ohos-image-kit-sys = {version = "0.2", optional = true, path = "components/multimedia/image_framework"}
+ohos-ime-sys = { version = "0.1.3", optional = true, path = "components/inputmethod"}
+ohos-input-sys = { version = "0.1.1", optional = true, path  = "components/multimodal-input"}
+ohos-rawfile-sys = { version = "0.1.0", optional = true, path = "components/rawfile"}
 ohos-sys-opaque-types = { workspace = true}
 ohos-vsync-sys = { version = "0.1.1", optional = true, path = "components/vsync"}
+xcomponent-sys = {version = "0.3.0", optional = true, path = "components/xcomponent"}
 
 
 [features]
@@ -48,6 +50,8 @@ hitrace = ["dep:hitrace-sys"]
 inputmethod = ["dep:ohos-ime-sys"]
 ## Bindings to the [Image Kit](https://docs.openharmony.cn/pages/v5.0/en/application-dev/media/image/image-overview.md)
 image-kit = ["dep:ohos-image-kit-sys"]
+## Bindings to the Multimodal Input kit.
+multimodal-input = ["dep:ohos-input-sys"]
 ## Enables bindings to `napi`
 napi = []
 ## Enables bindings to `native_buffer`
@@ -56,6 +60,8 @@ native_buffer = ['native_window']
 native_image = ['native_window']
 ## Enables bindings to `native_window`
 native_window = ['native_buffer']
+## Enables bindings to `rawfile`
+rawfile = ['ohos-rawfile-sys']
 ## Enables bindings to `native_vsync`
 vsync = ["dep:ohos-vsync-sys"]
 ## Enables bindings to `native_xcomponent`
@@ -73,10 +79,12 @@ all-components = [
     "image-kit-image-receiver",
     "image-kit-image-source",
     "image-kit-pixelmap",
+    "multimodal-input",
     "napi",
     "native_buffer",
     "native_image",
     "native_window",
+    "rawfile",
     "xcomponent",
     "vsync"]
 
@@ -89,50 +97,57 @@ all-components = [
 api-10 = []
 ## Enables bindings for OpenHarmony API-level 11
 api-11 = ["api-10",
-    "ohos-deviceinfo-sys?/api-11",
-    "ohos-drawing-sys?/api-11",
     "hilog-sys?/api-11",
     "hitrace-sys?/api-11",
-    "xcomponent-sys?/api-11",
+    "ohos-deviceinfo-sys?/api-11",
+    "ohos-drawing-sys?/api-11",
     "ohos-vsync-sys?/api-11",
+    "ohos-rawfile-sys?/api-11",
+    "xcomponent-sys?/api-11",
     ]
 ## Enables bindings for OpenHarmony API-level 12
 api-12 = ["api-11",
     "arkui-sys?/api-12",
-    "ohos-deviceinfo-sys?/api-12",
-    "ohos-drawing-sys?/api-12",
     "hilog-sys?/api-12",
     "hitrace-sys?/api-12",
-    "ohos-ime-sys?/api-12",
+    "ohos-deviceinfo-sys?/api-12",
+    "ohos-drawing-sys?/api-12",
     "ohos-image-kit-sys?/api-12",
-    "xcomponent-sys?/api-12",
+    "ohos-ime-sys?/api-12",
+    "ohos-input-sys?/api-12",
+    "ohos-rawfile-sys?/api-12",
     "ohos-vsync-sys?/api-12",
+    "xcomponent-sys?/api-12",
 ]
 
 ## Enables bindings for OpenHarmony API-level 13
 api-13 = ["api-12",
     "arkui-sys?/api-13",
-    "ohos-deviceinfo-sys?/api-13",
-    "ohos-drawing-sys?/api-13",
     "hilog-sys?/api-13",
     "hitrace-sys?/api-13",
-    "ohos-ime-sys?/api-13",
+    "ohos-deviceinfo-sys?/api-13",
+    "ohos-drawing-sys?/api-13",
     "ohos-image-kit-sys?/api-13",
-    "xcomponent-sys?/api-13",
+    "ohos-ime-sys?/api-13",
+    "ohos-input-sys?/api-13",
+    "ohos-rawfile-sys?/api-13",
     "ohos-vsync-sys?/api-13",
+    "xcomponent-sys?/api-13",
 ]
 
 ## Enables bindings for OpenHarmony API-level 13
 api-14 = ["api-13",
     "arkui-sys?/api-14",
-    # "ohos-deviceinfo-sys?/api-14",
     "ohos-drawing-sys?/api-14",
+    "ohos-image-kit-sys?/api-14",
+    "ohos-ime-sys?/api-14",
+    "ohos-input-sys?/api-14",
+    "ohos-vsync-sys?/api-14",
+    "xcomponent-sys?/api-14",
     # "hilog-sys?/api-14",
     # "hitrace-sys?/api-14",
-    "ohos-ime-sys?/api-14",
-    "ohos-image-kit-sys?/api-14",
-    "xcomponent-sys?/api-14",
-    "ohos-vsync-sys?/api-14",
+    # "ohos-rawfile-sys?/api-14",
+    # "ohos-deviceinfo-sys?/api-14",
 ]
 #! ### Features of dependencies
 #!

--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ already been generated.
 | inputmethod                | ✅      | 14        |
 | mindspore                  |        |           |
 | multimedia                 |        |           |
-| multimodalinput            |        |           |
+| multimodalinput            | ✅      | 14        |
 | napi                       | ✅      | 13        |
 | native_buffer              | ✅      | 14        |
 | native_color_space_manager |        |           |

--- a/components/multimedia/image_framework/Cargo.toml
+++ b/components/multimedia/image_framework/Cargo.toml
@@ -42,6 +42,8 @@ image-packer = []
 image-receiver = []
 ## Image decoding
 image-source = ["dep:ohos-rawfile-sys"]
+## Picture
+picture = ["pixelmap"]
 ## Pixel Map
 pixelmap = []
 ## Document available features when building the documentation

--- a/components/multimedia/image_framework/src/native_image.rs
+++ b/components/multimedia/image_framework/src/native_image.rs
@@ -4,10 +4,18 @@
 
 pub mod common;
 pub mod image;
+#[cfg(feature = "image-packer")]
+#[cfg_attr(docsrs, doc(cfg(feature = "image-packer")))]
 pub mod image_packer;
+#[cfg(feature = "image-receiver")]
+#[cfg_attr(docsrs, doc(cfg(feature = "image-receiver")))]
 pub mod image_receiver;
+#[cfg(feature = "image-source")]
+#[cfg_attr(docsrs, doc(cfg(feature = "image-source")))]
 pub mod image_source;
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
+#[cfg(all(feature = "api-13", feature = "pixelmap"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "api-13", feature = "pixelmap"))))]
 pub mod picture;
+#[cfg(feature = "pixelmap")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pixelmap")))]
 pub mod pixelmap;

--- a/components/multimedia/image_framework/src/native_image/picture.rs
+++ b/components/multimedia/image_framework/src/native_image/picture.rs
@@ -1,2 +1,5 @@
+#[link(name = "picture")]
+extern "C" {}
+
 mod picture_ffi;
 pub use picture_ffi::*;

--- a/components/multimodal-input/src/lib.rs
+++ b/components/multimodal-input/src/lib.rs
@@ -1,8 +1,8 @@
-//! Bindings to Input-kit API of OpenHarmony
+//! Bindings to the Multimodal Input-kit API of OpenHarmony
 //!
 //! Available with API-level 12 and newer
 //!
-//! Official documentation: https://developer.huawei.com/consumer/cn/doc/harmonyos-references-V5/_input_method-V5
+//! Official documentation: <https://developer.huawei.com/consumer/cn/doc/harmonyos-references-V14/input-V14>
 //!
 //! ## Feature flags
 #![cfg_attr(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,16 @@ pub use hilog_sys as hilog;
 #[cfg_attr(docsrs, doc(cfg(feature = "hitrace")))]
 pub use hitrace_sys as hitrace;
 
+#[cfg(feature = "inputmethod")]
+#[cfg_attr(docsrs, doc(cfg(feature = "inputmethod")))]
+pub use ohos_ime_sys as inputmethod;
+
+#[cfg(feature = "multimodal-input")]
+#[cfg_attr(docsrs, doc(cfg(feature = "multimodal-input")))]
+pub use ohos_input_sys as multimodal_input;
+
+pub mod multimedia;
+
 #[cfg(feature = "napi")]
 #[cfg_attr(docsrs, doc(cfg(feature = "napi")))]
 pub mod napi;

--- a/src/multimedia.rs
+++ b/src/multimedia.rs
@@ -1,0 +1,3 @@
+#[cfg(feature = "image-kit")]
+#[cfg_attr(docsrs, doc(cfg(feature = "image-kit")))]
+pub use ohos_image_kit_sys as image_kit;


### PR DESCRIPTION
Add missing components to ohos-sys.

We already generate these components, but didn't re-export them through ohos-sys,
which might hurt discoverablity.