### PR TITLE
Merge enum impl blocks

### DIFF
--- a/components/arkui/src/drag_and_drop/drag_and_drop_ffi.rs
+++ b/components/arkui/src/drag_and_drop/drag_and_drop_ffi.rs
@@ -11,16 +11,8 @@ pub use ohos_sys_opaque_types::OH_PixelmapNative;
 impl ArkUI_DragResult {
     /// The drag and drop operation succeeded.
     pub const SUCCESSFUL: ArkUI_DragResult = ArkUI_DragResult(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_DragResult {
     /// The drag and drop operation failed.
     pub const FAILED: ArkUI_DragResult = ArkUI_DragResult(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_DragResult {
     /// The drag and drop operation was canceled.
     pub const CANCELED: ArkUI_DragResult = ArkUI_DragResult(2);
 }
@@ -39,10 +31,6 @@ pub struct ArkUI_DragResult(pub ::core::ffi::c_uint);
 impl ArkUI_DropOperation {
     /// Copy.
     pub const ARKUI_DROP_OPERATION_COPY: ArkUI_DropOperation = ArkUI_DropOperation(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_DropOperation {
     /// Cut.
     pub const ARKUI_DROP_OPERATION_MOVE: ArkUI_DropOperation = ArkUI_DropOperation(1);
 }
@@ -60,51 +48,23 @@ pub struct ArkUI_DropOperation(pub ::core::ffi::c_uint);
 impl ArkUI_PreDragStatus {
     /// Unknown.
     pub const ARKUI_PRE_DRAG_STATUS_UNKNOWN: ArkUI_PreDragStatus = ArkUI_PreDragStatus(-1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_PreDragStatus {
     /// A drag gesture is being detected.
     pub const ARKUI_PRE_DRAG_STATUS_ACTION_DETECTING: ArkUI_PreDragStatus = ArkUI_PreDragStatus(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_PreDragStatus {
     /// The component is ready to be dragged.
     pub const ARKUI_PRE_DRAG_STATUS_READY_TO_TRIGGER_DRAG: ArkUI_PreDragStatus =
         ArkUI_PreDragStatus(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_PreDragStatus {
     /// A lift animation is started.
     pub const ARKUI_PRE_DRAG_STATUS_PREVIEW_LIFT_STARTED: ArkUI_PreDragStatus =
         ArkUI_PreDragStatus(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_PreDragStatus {
     /// A lift animation is finished.
     pub const ARKUI_PRE_DRAG_STATUS_PREVIEW_LIFT_FINISHED: ArkUI_PreDragStatus =
         ArkUI_PreDragStatus(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_PreDragStatus {
     /// A drop animation is started.
     pub const ARKUI_PRE_DRAG_STATUS_PREVIEW_LANDING_STARTED: ArkUI_PreDragStatus =
         ArkUI_PreDragStatus(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_PreDragStatus {
     /// A drop animation is finished.
     pub const ARKUI_PRE_DRAG_STATUS_PREVIEW_LANDING_FINISHED: ArkUI_PreDragStatus =
         ArkUI_PreDragStatus(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_PreDragStatus {
     /// A drop animation is terminated.
     pub const ARKUI_PRE_DRAG_STATUS_CANCELED_BEFORE_DRAG: ArkUI_PreDragStatus =
         ArkUI_PreDragStatus(6);
@@ -125,10 +85,6 @@ impl ArkUI_DragPreviewScaleMode {
     /// scales the drag preview based on set rules.
     pub const ARKUI_DRAG_PREVIEW_SCALE_AUTO: ArkUI_DragPreviewScaleMode =
         ArkUI_DragPreviewScaleMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_DragPreviewScaleMode {
     /// The system does not scale the drag preview.
     pub const ARKUI_DRAG_PREVIEW_SCALE_DISABLED: ArkUI_DragPreviewScaleMode =
         ArkUI_DragPreviewScaleMode(1);
@@ -147,16 +103,8 @@ pub struct ArkUI_DragPreviewScaleMode(pub ::core::ffi::c_uint);
 impl ArkUI_DragStatus {
     /// Unknown.
     pub const ARKUI_DRAG_STATUS_UNKNOWN: ArkUI_DragStatus = ArkUI_DragStatus(-1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_DragStatus {
     /// Started.
     pub const ARKUI_DRAG_STATUS_STARTED: ArkUI_DragStatus = ArkUI_DragStatus(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_DragStatus {
     /// Ended.
     pub const ARKUI_DRAG_STATUS_ENDED: ArkUI_DragStatus = ArkUI_DragStatus(1);
 }

--- a/components/arkui/src/native_dialog/native_dialog_ffi.rs
+++ b/components/arkui/src/native_dialog/native_dialog_ffi.rs
@@ -10,22 +10,10 @@ use crate::native_type::*;
 impl ArkUI_DismissReason {
     /// Touching the system-defined Back button or pressing the Esc key.
     pub const DIALOG_DISMISS_BACK_PRESS: ArkUI_DismissReason = ArkUI_DismissReason(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_DismissReason {
     /// Touching the mask.
     pub const DIALOG_DISMISS_TOUCH_OUTSIDE: ArkUI_DismissReason = ArkUI_DismissReason(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_DismissReason {
     /// Touching the Close button.
     pub const DIALOG_DISMISS_CLOSE_BUTTON: ArkUI_DismissReason = ArkUI_DismissReason(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_DismissReason {
     /// Sliding down.
     pub const DIALOG_DISMISS_SLIDE_DOWN: ArkUI_DismissReason = ArkUI_DismissReason(3);
 }

--- a/components/arkui/src/native_gesture/native_gesture_ffi.rs
+++ b/components/arkui/src/native_gesture/native_gesture_ffi.rs
@@ -24,24 +24,12 @@ impl ArkUI_GestureEventActionType {
     /// Triggered.
     pub const GESTURE_EVENT_ACTION_ACCEPT: ArkUI_GestureEventActionType =
         ArkUI_GestureEventActionType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureEventActionType {
     /// Updated.
     pub const GESTURE_EVENT_ACTION_UPDATE: ArkUI_GestureEventActionType =
         ArkUI_GestureEventActionType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureEventActionType {
     /// Ended.
     pub const GESTURE_EVENT_ACTION_END: ArkUI_GestureEventActionType =
         ArkUI_GestureEventActionType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureEventActionType {
     /// Canceled.
     pub const GESTURE_EVENT_ACTION_CANCEL: ArkUI_GestureEventActionType =
         ArkUI_GestureEventActionType(8);
@@ -70,16 +58,8 @@ pub type ArkUI_GestureEventActionTypeMask = u32;
 impl ArkUI_GesturePriority {
     /// Normal.
     pub const NORMAL: ArkUI_GesturePriority = ArkUI_GesturePriority(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GesturePriority {
     /// High-priority.
     pub const PRIORITY: ArkUI_GesturePriority = ArkUI_GesturePriority(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GesturePriority {
     /// Parallel.
     pub const PARALLEL: ArkUI_GesturePriority = ArkUI_GesturePriority(2);
 }
@@ -96,17 +76,9 @@ pub struct ArkUI_GesturePriority(pub ::core::ffi::c_uint);
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl ArkUI_GroupGestureMode {
     pub const SEQUENTIAL_GROUP: ArkUI_GroupGestureMode = ArkUI_GroupGestureMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GroupGestureMode {
     /// Parallel recognition. Registered gestures are recognized concurrently until all gestures are recognized.
     /// The recognition result of each gesture does not affect each other.
     pub const PARALLEL_GROUP: ArkUI_GroupGestureMode = ArkUI_GroupGestureMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GroupGestureMode {
     /// Exclusive recognition. Registered gestures are identified concurrently.
     /// If one gesture is successfully recognized, gesture recognition ends.
     pub const EXCLUSIVE_GROUP: ArkUI_GroupGestureMode = ArkUI_GroupGestureMode(2);
@@ -125,46 +97,18 @@ pub struct ArkUI_GroupGestureMode(pub ::core::ffi::c_uint);
 impl ArkUI_GestureDirection {
     /// All directions.
     pub const GESTURE_DIRECTION_ALL: ArkUI_GestureDirection = ArkUI_GestureDirection(15);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureDirection {
     /// Horizontal direction.
     pub const GESTURE_DIRECTION_HORIZONTAL: ArkUI_GestureDirection = ArkUI_GestureDirection(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureDirection {
     /// Vertical direction.
     pub const GESTURE_DIRECTION_VERTICAL: ArkUI_GestureDirection = ArkUI_GestureDirection(12);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureDirection {
     /// Leftward.
     pub const GESTURE_DIRECTION_LEFT: ArkUI_GestureDirection = ArkUI_GestureDirection(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureDirection {
     /// Rightward.
     pub const GESTURE_DIRECTION_RIGHT: ArkUI_GestureDirection = ArkUI_GestureDirection(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureDirection {
     /// Upward.
     pub const GESTURE_DIRECTION_UP: ArkUI_GestureDirection = ArkUI_GestureDirection(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureDirection {
     /// Downward.
     pub const GESTURE_DIRECTION_DOWN: ArkUI_GestureDirection = ArkUI_GestureDirection(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureDirection {
     /// None.
     pub const GESTURE_DIRECTION_NONE: ArkUI_GestureDirection = ArkUI_GestureDirection(0);
 }
@@ -194,10 +138,6 @@ pub type ArkUI_GestureDirectionMask = u32;
 impl ArkUI_GestureMask {
     /// The gestures of child components are enabled and recognized based on the default gesture recognition sequence.
     pub const NORMAL_GESTURE_MASK: ArkUI_GestureMask = ArkUI_GestureMask(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureMask {
     /// The gestures of child components are disabled, including the built-in gestures.
     pub const IGNORE_INTERNAL_GESTURE_MASK: ArkUI_GestureMask = ArkUI_GestureMask(1);
 }
@@ -215,40 +155,16 @@ pub struct ArkUI_GestureMask(pub ::core::ffi::c_uint);
 impl ArkUI_GestureRecognizerType {
     /// Tap.
     pub const TAP_GESTURE: ArkUI_GestureRecognizerType = ArkUI_GestureRecognizerType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureRecognizerType {
     /// Long press.
     pub const LONG_PRESS_GESTURE: ArkUI_GestureRecognizerType = ArkUI_GestureRecognizerType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureRecognizerType {
     /// Pan.
     pub const PAN_GESTURE: ArkUI_GestureRecognizerType = ArkUI_GestureRecognizerType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureRecognizerType {
     /// Pinch.
     pub const PINCH_GESTURE: ArkUI_GestureRecognizerType = ArkUI_GestureRecognizerType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureRecognizerType {
     /// Rotate.
     pub const ROTATION_GESTURE: ArkUI_GestureRecognizerType = ArkUI_GestureRecognizerType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureRecognizerType {
     /// Swipe.
     pub const SWIPE_GESTURE: ArkUI_GestureRecognizerType = ArkUI_GestureRecognizerType(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureRecognizerType {
     /// A group of gestures.
     pub const GROUP_GESTURE: ArkUI_GestureRecognizerType = ArkUI_GestureRecognizerType(6);
 }
@@ -266,10 +182,6 @@ pub struct ArkUI_GestureRecognizerType(pub ::core::ffi::c_uint);
 impl ArkUI_GestureInterruptResult {
     /// The gesture recognition process continues.
     pub const CONTINUE: ArkUI_GestureInterruptResult = ArkUI_GestureInterruptResult(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureInterruptResult {
     /// The gesture recognition process is paused.
     pub const REJECT: ArkUI_GestureInterruptResult = ArkUI_GestureInterruptResult(1);
 }
@@ -288,38 +200,18 @@ impl ArkUI_GestureRecognizerState {
     /// Ready.
     pub const ARKUI_GESTURE_RECOGNIZER_STATE_READY: ArkUI_GestureRecognizerState =
         ArkUI_GestureRecognizerState(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureRecognizerState {
     /// Detecting.
     pub const ARKUI_GESTURE_RECOGNIZER_STATE_DETECTING: ArkUI_GestureRecognizerState =
         ArkUI_GestureRecognizerState(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureRecognizerState {
     /// Pending.
     pub const ARKUI_GESTURE_RECOGNIZER_STATE_PENDING: ArkUI_GestureRecognizerState =
         ArkUI_GestureRecognizerState(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureRecognizerState {
     /// Blocked.
     pub const ARKUI_GESTURE_RECOGNIZER_STATE_BLOCKED: ArkUI_GestureRecognizerState =
         ArkUI_GestureRecognizerState(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureRecognizerState {
     /// Successful.
     pub const ARKUI_GESTURE_RECOGNIZER_STATE_SUCCESSFUL: ArkUI_GestureRecognizerState =
         ArkUI_GestureRecognizerState(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_GestureRecognizerState {
     /// Failed.
     pub const ARKUI_GESTURE_RECOGNIZER_STATE_FAILED: ArkUI_GestureRecognizerState =
         ArkUI_GestureRecognizerState(5);

--- a/components/arkui/src/native_interface/native_interface_ffi.rs
+++ b/components/arkui/src/native_interface/native_interface_ffi.rs
@@ -10,22 +10,10 @@ use crate::native_type::*;
 impl ArkUI_NativeAPIVariantKind {
     /// API related to UI components. For details, see the struct definition in <arkui/native_node.h>.
     pub const ARKUI_NATIVE_NODE: ArkUI_NativeAPIVariantKind = ArkUI_NativeAPIVariantKind(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NativeAPIVariantKind {
     /// API related to dialog boxes. For details, see the struct definition in <arkui/native_dialog.h>.
     pub const ARKUI_NATIVE_DIALOG: ArkUI_NativeAPIVariantKind = ArkUI_NativeAPIVariantKind(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NativeAPIVariantKind {
     /// API related to gestures. For details, see the struct definition in <arkui/native_gesture.h>.
     pub const ARKUI_NATIVE_GESTURE: ArkUI_NativeAPIVariantKind = ArkUI_NativeAPIVariantKind(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NativeAPIVariantKind {
     /// API related to animations. For details, see the struct definition in <arkui/native_animate.h>.
     pub const ARKUI_NATIVE_ANIMATE: ArkUI_NativeAPIVariantKind = ArkUI_NativeAPIVariantKind(3);
 }

--- a/components/arkui/src/native_interface_accessibility/native_interface_accessibility_ffi.rs
+++ b/components/arkui/src/native_interface_accessibility/native_interface_accessibility_ffi.rs
@@ -24,88 +24,40 @@ impl ArkUI_Accessibility_ActionType {
     /// Invalid action.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_INVALID: ArkUI_Accessibility_ActionType =
         ArkUI_Accessibility_ActionType(0);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Response to a click.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_CLICK: ArkUI_Accessibility_ActionType =
         ArkUI_Accessibility_ActionType(16);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Response to a long click.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_LONG_CLICK: ArkUI_Accessibility_ActionType =
         ArkUI_Accessibility_ActionType(32);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Accessibility focus acquisition.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_GAIN_ACCESSIBILITY_FOCUS:
         ArkUI_Accessibility_ActionType = ArkUI_Accessibility_ActionType(64);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Accessibility focus clearance.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_CLEAR_ACCESSIBILITY_FOCUS:
         ArkUI_Accessibility_ActionType = ArkUI_Accessibility_ActionType(128);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Forward scroll action.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_SCROLL_FORWARD:
         ArkUI_Accessibility_ActionType = ArkUI_Accessibility_ActionType(256);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Backward scroll action.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_SCROLL_BACKWARD:
         ArkUI_Accessibility_ActionType = ArkUI_Accessibility_ActionType(512);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Copy action for text content.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_COPY: ArkUI_Accessibility_ActionType =
         ArkUI_Accessibility_ActionType(1024);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Paste action for text content.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_PASTE: ArkUI_Accessibility_ActionType =
         ArkUI_Accessibility_ActionType(2048);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Cut action for text content.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_CUT: ArkUI_Accessibility_ActionType =
         ArkUI_Accessibility_ActionType(4096);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Text selection action, requiring the setting of <b>selectTextBegin</b>, <b>TextEnd</b>, and <b>TextInForward</b>
     /// parameters to select a text segment in the text box.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_SELECT_TEXT: ArkUI_Accessibility_ActionType =
         ArkUI_Accessibility_ActionType(8192);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Text content setting action.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_SET_TEXT: ArkUI_Accessibility_ActionType =
         ArkUI_Accessibility_ActionType(16384);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_Accessibility_ActionType {
     /// Cursor position setting action.
     pub const ARKUI_ACCESSIBILITY_NATIVE_ACTION_TYPE_SET_CURSOR_POSITION:
         ArkUI_Accessibility_ActionType = ArkUI_Accessibility_ActionType(1048576);
@@ -125,101 +77,45 @@ impl ArkUI_AccessibilityEventType {
     /// Invalid event.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_INVALID: ArkUI_AccessibilityEventType =
         ArkUI_AccessibilityEventType(0);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Click event, sent after the UI component responds.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_CLICKED: ArkUI_AccessibilityEventType =
         ArkUI_AccessibilityEventType(1);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Long click event, sent after the UI component responds.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_LONG_CLICKED: ArkUI_AccessibilityEventType =
         ArkUI_AccessibilityEventType(2);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Selection event, sent after the UI component responds.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_SELECTED: ArkUI_AccessibilityEventType =
         ArkUI_AccessibilityEventType(4);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Text update event, sent when text is updated.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_TEXT_UPDATE: ArkUI_AccessibilityEventType =
         ArkUI_AccessibilityEventType(16);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Page state update event, sent when the page transitions, switches, resizes, or moves.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_PAGE_STATE_UPDATE:
         ArkUI_AccessibilityEventType = ArkUI_AccessibilityEventType(32);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Page content update event, sent when the page content changes.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_PAGE_CONTENT_UPDATE:
         ArkUI_AccessibilityEventType = ArkUI_AccessibilityEventType(2048);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Scrolled event, sent when a scrollable component experiences a scroll event.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_SCROLLED: ArkUI_AccessibilityEventType =
         ArkUI_AccessibilityEventType(4096);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Accessibility focus event, sent after the UI component responds.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_ACCESSIBILITY_FOCUSED:
         ArkUI_AccessibilityEventType = ArkUI_AccessibilityEventType(32768);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Accessibility focus cleared event, sent after the UI component responds.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_ACCESSIBILITY_FOCUS_CLEARED:
         ArkUI_AccessibilityEventType = ArkUI_AccessibilityEventType(65536);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// FOcus request for a specific node.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_REQUEST_ACCESSIBILITY_FOCUS:
         ArkUI_AccessibilityEventType = ArkUI_AccessibilityEventType(33554432);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Page open event reported by the UI component.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_PAGE_OPEN: ArkUI_AccessibilityEventType =
         ArkUI_AccessibilityEventType(536870912);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Page close event reported by the UI component.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_PAGE_CLOSE: ArkUI_AccessibilityEventType =
         ArkUI_AccessibilityEventType(134217728);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Announcement event, indicating a request to proactively announce specified content.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_ANNOUNCE_FOR_ACCESSIBILITY:
         ArkUI_AccessibilityEventType = ArkUI_AccessibilityEventType(268435456);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityEventType {
     /// Focus update event, used for focus update scenarios.
     pub const ARKUI_ACCESSIBILITY_NATIVE_EVENT_TYPE_FOCUS_NODE_UPDATE:
         ArkUI_AccessibilityEventType = ArkUI_AccessibilityEventType(268435457);
@@ -325,24 +221,12 @@ impl ArkUI_AcessbilityErrorCode {
     /// Success.
     pub const ARKUI_ACCESSIBILITY_NATIVE_RESULT_SUCCESSFUL: ArkUI_AcessbilityErrorCode =
         ArkUI_AcessbilityErrorCode(0);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AcessbilityErrorCode {
     /// Failure.
     pub const ARKUI_ACCESSIBILITY_NATIVE_RESULT_FAILED: ArkUI_AcessbilityErrorCode =
         ArkUI_AcessbilityErrorCode(-1);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AcessbilityErrorCode {
     /// Invalid parameter.
     pub const ARKUI_ACCESSIBILITY_NATIVE_RESULT_BAD_PARAMETER: ArkUI_AcessbilityErrorCode =
         ArkUI_AcessbilityErrorCode(-2);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AcessbilityErrorCode {
     /// Out of memory.
     pub const ARKUI_ACCESSIBILITY_NATIVE_RESULT_OUT_OF_MEMORY: ArkUI_AcessbilityErrorCode =
         ArkUI_AcessbilityErrorCode(-3);
@@ -362,31 +246,15 @@ impl ArkUI_AccessibilitySearchMode {
     /// Search for current nodes.
     pub const ARKUI_ACCESSIBILITY_NATIVE_SEARCH_MODE_PREFETCH_CURRENT:
         ArkUI_AccessibilitySearchMode = ArkUI_AccessibilitySearchMode(0);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilitySearchMode {
     /// Search for parent nodes.
     pub const ARKUI_ACCESSIBILITY_NATIVE_SEARCH_MODE_PREFETCH_PREDECESSORS:
         ArkUI_AccessibilitySearchMode = ArkUI_AccessibilitySearchMode(1);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilitySearchMode {
     /// Search for sibling nodes.
     pub const ARKUI_ACCESSIBILITY_NATIVE_SEARCH_MODE_PREFETCH_SIBLINGS:
         ArkUI_AccessibilitySearchMode = ArkUI_AccessibilitySearchMode(2);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilitySearchMode {
     /// Search for child nodes at the next level.
     pub const ARKUI_ACCESSIBILITY_NATIVE_SEARCH_MODE_PREFETCH_CHILDREN:
         ArkUI_AccessibilitySearchMode = ArkUI_AccessibilitySearchMode(4);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilitySearchMode {
     /// Search for all child nodes.
     pub const ARKUI_ACCESSIBILITY_NATIVE_SEARCH_MODE_PREFETCH_RECURSIVE_CHILDREN:
         ArkUI_AccessibilitySearchMode = ArkUI_AccessibilitySearchMode(8);
@@ -406,17 +274,9 @@ impl ArkUI_AccessibilityFocusType {
     /// Invalid type.
     pub const ARKUI_ACCESSIBILITY_NATIVE_FOCUS_TYPE_INVALID: ArkUI_AccessibilityFocusType =
         ArkUI_AccessibilityFocusType(-1);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityFocusType {
     /// Input focus type.
     pub const ARKUI_ACCESSIBILITY_NATIVE_FOCUS_TYPE_INPUT: ArkUI_AccessibilityFocusType =
         ArkUI_AccessibilityFocusType(1);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityFocusType {
     /// Accessibility focus type.
     pub const ARKUI_ACCESSIBILITY_NATIVE_FOCUS_TYPE_ACCESSIBILITY: ArkUI_AccessibilityFocusType =
         ArkUI_AccessibilityFocusType(2);
@@ -436,45 +296,21 @@ impl ArkUI_AccessibilityFocusMoveDirection {
     /// Invalid direction.
     pub const ARKUI_ACCESSIBILITY_NATIVE_DIRECTION_INVALID: ArkUI_AccessibilityFocusMoveDirection =
         ArkUI_AccessibilityFocusMoveDirection(0);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityFocusMoveDirection {
     /// Up.
     pub const ARKUI_ACCESSIBILITY_NATIVE_DIRECTION_UP: ArkUI_AccessibilityFocusMoveDirection =
         ArkUI_AccessibilityFocusMoveDirection(1);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityFocusMoveDirection {
     /// Down.
     pub const ARKUI_ACCESSIBILITY_NATIVE_DIRECTION_DOWN: ArkUI_AccessibilityFocusMoveDirection =
         ArkUI_AccessibilityFocusMoveDirection(2);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityFocusMoveDirection {
     /// Left.
     pub const ARKUI_ACCESSIBILITY_NATIVE_DIRECTION_LEFT: ArkUI_AccessibilityFocusMoveDirection =
         ArkUI_AccessibilityFocusMoveDirection(4);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityFocusMoveDirection {
     /// Right.
     pub const ARKUI_ACCESSIBILITY_NATIVE_DIRECTION_RIGHT: ArkUI_AccessibilityFocusMoveDirection =
         ArkUI_AccessibilityFocusMoveDirection(8);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityFocusMoveDirection {
     /// Forward.
     pub const ARKUI_ACCESSIBILITY_NATIVE_DIRECTION_FORWARD: ArkUI_AccessibilityFocusMoveDirection =
         ArkUI_AccessibilityFocusMoveDirection(16);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl ArkUI_AccessibilityFocusMoveDirection {
     /// Backward.
     pub const ARKUI_ACCESSIBILITY_NATIVE_DIRECTION_BACKWARD: ArkUI_AccessibilityFocusMoveDirection =
         ArkUI_AccessibilityFocusMoveDirection(32);

--- a/components/arkui/src/native_key_event/native_key_event_ffi.rs
+++ b/components/arkui/src/native_key_event/native_key_event_ffi.rs
@@ -11,796 +11,268 @@ use crate::ui_input_event::ArkUI_UIInputEvent;
 impl ArkUI_KeyCode {
     /// Unknown (or unrecognized) key
     pub const ARKUI_KEYCODE_UNKNOWN: ArkUI_KeyCode = ArkUI_KeyCode(-1);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Function (Fn) key
     pub const ARKUI_KEYCODE_FN: ArkUI_KeyCode = ArkUI_KeyCode(0);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Volume Up key
     pub const ARKUI_KEYCODE_VOLUME_UP: ArkUI_KeyCode = ArkUI_KeyCode(16);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Volume Down key
     pub const ARKUI_KEYCODE_VOLUME_DOWN: ArkUI_KeyCode = ArkUI_KeyCode(17);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Power key
     pub const ARKUI_KEYCODE_POWER: ArkUI_KeyCode = ArkUI_KeyCode(18);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Shutter key
     pub const ARKUI_KEYCODE_CAMERA: ArkUI_KeyCode = ArkUI_KeyCode(19);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Speaker Mute key
     pub const ARKUI_KEYCODE_VOLUME_MUTE: ArkUI_KeyCode = ArkUI_KeyCode(22);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Mute key
     pub const ARKUI_KEYCODE_MUTE: ArkUI_KeyCode = ArkUI_KeyCode(23);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Brightness Up key
     pub const ARKUI_KEYCODE_BRIGHTNESS_UP: ArkUI_KeyCode = ArkUI_KeyCode(40);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Brightness Down key
     pub const ARKUI_KEYCODE_BRIGHTNESS_DOWN: ArkUI_KeyCode = ArkUI_KeyCode(41);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 0
     pub const ARKUI_KEYCODE_0: ArkUI_KeyCode = ArkUI_KeyCode(2000);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 1
     pub const ARKUI_KEYCODE_1: ArkUI_KeyCode = ArkUI_KeyCode(2001);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 2
     pub const ARKUI_KEYCODE_2: ArkUI_KeyCode = ArkUI_KeyCode(2002);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 3
     pub const ARKUI_KEYCODE_3: ArkUI_KeyCode = ArkUI_KeyCode(2003);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 4
     pub const ARKUI_KEYCODE_4: ArkUI_KeyCode = ArkUI_KeyCode(2004);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 5
     pub const ARKUI_KEYCODE_5: ArkUI_KeyCode = ArkUI_KeyCode(2005);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 6
     pub const ARKUI_KEYCODE_6: ArkUI_KeyCode = ArkUI_KeyCode(2006);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 7
     pub const ARKUI_KEYCODE_7: ArkUI_KeyCode = ArkUI_KeyCode(2007);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 8
     pub const ARKUI_KEYCODE_8: ArkUI_KeyCode = ArkUI_KeyCode(2008);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 9
     pub const ARKUI_KEYCODE_9: ArkUI_KeyCode = ArkUI_KeyCode(2009);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key +
     pub const ARKUI_KEYCODE_STAR: ArkUI_KeyCode = ArkUI_KeyCode(2010);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key #
     pub const ARKUI_KEYCODE_POUND: ArkUI_KeyCode = ArkUI_KeyCode(2011);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Up key on D-pad
     pub const ARKUI_KEYCODE_DPAD_UP: ArkUI_KeyCode = ArkUI_KeyCode(2012);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Down key on D-pad
     pub const ARKUI_KEYCODE_DPAD_DOWN: ArkUI_KeyCode = ArkUI_KeyCode(2013);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Left key on D-pad
     pub const ARKUI_KEYCODE_DPAD_LEFT: ArkUI_KeyCode = ArkUI_KeyCode(2014);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Right key on D-pad
     pub const ARKUI_KEYCODE_DPAD_RIGHT: ArkUI_KeyCode = ArkUI_KeyCode(2015);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// OK key on D-pad
     pub const ARKUI_KEYCODE_DPAD_CENTER: ArkUI_KeyCode = ArkUI_KeyCode(2016);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key A
     pub const ARKUI_KEYCODE_A: ArkUI_KeyCode = ArkUI_KeyCode(2017);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key B
     pub const ARKUI_KEYCODE_B: ArkUI_KeyCode = ArkUI_KeyCode(2018);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key C
     pub const ARKUI_KEYCODE_C: ArkUI_KeyCode = ArkUI_KeyCode(2019);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key D
     pub const ARKUI_KEYCODE_D: ArkUI_KeyCode = ArkUI_KeyCode(2020);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key E
     pub const ARKUI_KEYCODE_E: ArkUI_KeyCode = ArkUI_KeyCode(2021);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key F
     pub const ARKUI_KEYCODE_F: ArkUI_KeyCode = ArkUI_KeyCode(2022);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key G
     pub const ARKUI_KEYCODE_G: ArkUI_KeyCode = ArkUI_KeyCode(2023);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key H
     pub const ARKUI_KEYCODE_H: ArkUI_KeyCode = ArkUI_KeyCode(2024);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key I
     pub const ARKUI_KEYCODE_I: ArkUI_KeyCode = ArkUI_KeyCode(2025);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key J
     pub const ARKUI_KEYCODE_J: ArkUI_KeyCode = ArkUI_KeyCode(2026);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key K
     pub const ARKUI_KEYCODE_K: ArkUI_KeyCode = ArkUI_KeyCode(2027);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key L
     pub const ARKUI_KEYCODE_L: ArkUI_KeyCode = ArkUI_KeyCode(2028);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key M
     pub const ARKUI_KEYCODE_M: ArkUI_KeyCode = ArkUI_KeyCode(2029);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key N
     pub const ARKUI_KEYCODE_N: ArkUI_KeyCode = ArkUI_KeyCode(2030);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key O
     pub const ARKUI_KEYCODE_O: ArkUI_KeyCode = ArkUI_KeyCode(2031);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key P
     pub const ARKUI_KEYCODE_P: ArkUI_KeyCode = ArkUI_KeyCode(2032);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key R
     pub const ARKUI_KEYCODE_Q: ArkUI_KeyCode = ArkUI_KeyCode(2033);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key R
     pub const ARKUI_KEYCODE_R: ArkUI_KeyCode = ArkUI_KeyCode(2034);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key S
     pub const ARKUI_KEYCODE_S: ArkUI_KeyCode = ArkUI_KeyCode(2035);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key T
     pub const ARKUI_KEYCODE_T: ArkUI_KeyCode = ArkUI_KeyCode(2036);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key U
     pub const ARKUI_KEYCODE_U: ArkUI_KeyCode = ArkUI_KeyCode(2037);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key V
     pub const ARKUI_KEYCODE_V: ArkUI_KeyCode = ArkUI_KeyCode(2038);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key W
     pub const ARKUI_KEYCODE_W: ArkUI_KeyCode = ArkUI_KeyCode(2039);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key X
     pub const ARKUI_KEYCODE_X: ArkUI_KeyCode = ArkUI_KeyCode(2040);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key Y
     pub const ARKUI_KEYCODE_Y: ArkUI_KeyCode = ArkUI_KeyCode(2041);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key Z
     pub const ARKUI_KEYCODE_Z: ArkUI_KeyCode = ArkUI_KeyCode(2042);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key #
     pub const ARKUI_KEYCODE_COMMA: ArkUI_KeyCode = ArkUI_KeyCode(2043);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key #
     pub const ARKUI_KEYCODE_PERIOD: ArkUI_KeyCode = ArkUI_KeyCode(2044);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Left Alt key
     pub const ARKUI_KEYCODE_ALT_LEFT: ArkUI_KeyCode = ArkUI_KeyCode(2045);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Right Alt key
     pub const ARKUI_KEYCODE_ALT_RIGHT: ArkUI_KeyCode = ArkUI_KeyCode(2046);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Left Shift key
     pub const ARKUI_KEYCODE_SHIFT_LEFT: ArkUI_KeyCode = ArkUI_KeyCode(2047);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Right Shift key
     pub const ARKUI_KEYCODE_SHIFT_RIGHT: ArkUI_KeyCode = ArkUI_KeyCode(2048);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Tab key
     pub const ARKUI_KEYCODE_TAB: ArkUI_KeyCode = ArkUI_KeyCode(2049);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Space key
     pub const ARKUI_KEYCODE_SPACE: ArkUI_KeyCode = ArkUI_KeyCode(2050);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Symbol key
     pub const ARKUI_KEYCODE_SYM: ArkUI_KeyCode = ArkUI_KeyCode(2051);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Explorer key, used to start the explorer application
     pub const ARKUI_KEYCODE_EXPLORER: ArkUI_KeyCode = ArkUI_KeyCode(2052);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Email key, used to start the email application
     pub const ARKUI_KEYCODE_ENVELOPE: ArkUI_KeyCode = ArkUI_KeyCode(2053);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Enter key
     pub const ARKUI_KEYCODE_ENTER: ArkUI_KeyCode = ArkUI_KeyCode(2054);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Backspace key
     pub const ARKUI_KEYCODE_DEL: ArkUI_KeyCode = ArkUI_KeyCode(2055);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key `
     pub const ARKUI_KEYCODE_GRAVE: ArkUI_KeyCode = ArkUI_KeyCode(2056);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key -
     pub const ARKUI_KEYCODE_MINUS: ArkUI_KeyCode = ArkUI_KeyCode(2057);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key =
     pub const ARKUI_KEYCODE_EQUALS: ArkUI_KeyCode = ArkUI_KeyCode(2058);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key [
     pub const ARKUI_KEYCODE_LEFT_BRACKET: ArkUI_KeyCode = ArkUI_KeyCode(2059);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key ]
     pub const ARKUI_KEYCODE_RIGHT_BRACKET: ArkUI_KeyCode = ArkUI_KeyCode(2060);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key
     pub const ARKUI_KEYCODE_BACKSLASH: ArkUI_KeyCode = ArkUI_KeyCode(2061);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key ;
     pub const ARKUI_KEYCODE_SEMICOLON: ArkUI_KeyCode = ArkUI_KeyCode(2062);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key '
     pub const ARKUI_KEYCODE_APOSTROPHE: ArkUI_KeyCode = ArkUI_KeyCode(2063);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key /
     pub const ARKUI_KEYCODE_SLASH: ArkUI_KeyCode = ArkUI_KeyCode(2064);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key
     pub const ARKUI_KEYCODE_AT: ArkUI_KeyCode = ArkUI_KeyCode(2065);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key +
     pub const ARKUI_KEYCODE_PLUS: ArkUI_KeyCode = ArkUI_KeyCode(2066);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Menu key
     pub const ARKUI_KEYCODE_MENU: ArkUI_KeyCode = ArkUI_KeyCode(2067);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Page Up key
     pub const ARKUI_KEYCODE_PAGE_UP: ArkUI_KeyCode = ArkUI_KeyCode(2068);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Page Down key
     pub const ARKUI_KEYCODE_PAGE_DOWN: ArkUI_KeyCode = ArkUI_KeyCode(2069);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// ESC key
     pub const ARKUI_KEYCODE_ESCAPE: ArkUI_KeyCode = ArkUI_KeyCode(2070);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Delete key
     pub const ARKUI_KEYCODE_FORWARD_DEL: ArkUI_KeyCode = ArkUI_KeyCode(2071);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Left Ctrl key
     pub const ARKUI_KEYCODE_CTRL_LEFT: ArkUI_KeyCode = ArkUI_KeyCode(2072);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Right Ctrl key
     pub const ARKUI_KEYCODE_CTRL_RIGHT: ArkUI_KeyCode = ArkUI_KeyCode(2073);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Caps Lock key
     pub const ARKUI_KEYCODE_CAPS_LOCK: ArkUI_KeyCode = ArkUI_KeyCode(2074);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Scroll Lock key
     pub const ARKUI_KEYCODE_SCROLL_LOCK: ArkUI_KeyCode = ArkUI_KeyCode(2075);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Left Meta key
     pub const ARKUI_KEYCODE_META_LEFT: ArkUI_KeyCode = ArkUI_KeyCode(2076);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Right Meta key
     pub const ARKUI_KEYCODE_META_RIGHT: ArkUI_KeyCode = ArkUI_KeyCode(2077);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Function key
     pub const ARKUI_KEYCODE_FUNCTION: ArkUI_KeyCode = ArkUI_KeyCode(2078);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// System Request/Print Screen key
     pub const ARKUI_KEYCODE_SYSRQ: ArkUI_KeyCode = ArkUI_KeyCode(2079);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Break/Pause key
     pub const ARKUI_KEYCODE_BREAK: ArkUI_KeyCode = ArkUI_KeyCode(2080);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Move to Home key
     pub const ARKUI_KEYCODE_MOVE_HOME: ArkUI_KeyCode = ArkUI_KeyCode(2081);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Move to End key
     pub const ARKUI_KEYCODE_MOVE_END: ArkUI_KeyCode = ArkUI_KeyCode(2082);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Insert key
     pub const ARKUI_KEYCODE_INSERT: ArkUI_KeyCode = ArkUI_KeyCode(2083);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Forward key
     pub const ARKUI_KEYCODE_FORWARD: ArkUI_KeyCode = ArkUI_KeyCode(2084);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Play key
     pub const ARKUI_KEYCODE_MEDIA_PLAY: ArkUI_KeyCode = ArkUI_KeyCode(2085);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Pause key
     pub const ARKUI_KEYCODE_MEDIA_PAUSE: ArkUI_KeyCode = ArkUI_KeyCode(2086);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Close key
     pub const ARKUI_KEYCODE_MEDIA_CLOSE: ArkUI_KeyCode = ArkUI_KeyCode(2087);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Eject key
     pub const ARKUI_KEYCODE_MEDIA_EJECT: ArkUI_KeyCode = ArkUI_KeyCode(2088);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Record key
     pub const ARKUI_KEYCODE_MEDIA_RECORD: ArkUI_KeyCode = ArkUI_KeyCode(2089);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F1 key
     pub const ARKUI_KEYCODE_F1: ArkUI_KeyCode = ArkUI_KeyCode(2090);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F2 key
     pub const ARKUI_KEYCODE_F2: ArkUI_KeyCode = ArkUI_KeyCode(2091);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F3 key
     pub const ARKUI_KEYCODE_F3: ArkUI_KeyCode = ArkUI_KeyCode(2092);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F4 key
     pub const ARKUI_KEYCODE_F4: ArkUI_KeyCode = ArkUI_KeyCode(2093);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F5 key
     pub const ARKUI_KEYCODE_F5: ArkUI_KeyCode = ArkUI_KeyCode(2094);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F6 key
     pub const ARKUI_KEYCODE_F6: ArkUI_KeyCode = ArkUI_KeyCode(2095);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F7 key
     pub const ARKUI_KEYCODE_F7: ArkUI_KeyCode = ArkUI_KeyCode(2096);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F8 key
     pub const ARKUI_KEYCODE_F8: ArkUI_KeyCode = ArkUI_KeyCode(2097);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F9 key
     pub const ARKUI_KEYCODE_F9: ArkUI_KeyCode = ArkUI_KeyCode(2098);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F10 key
     pub const ARKUI_KEYCODE_F10: ArkUI_KeyCode = ArkUI_KeyCode(2099);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F11 key
     pub const ARKUI_KEYCODE_F11: ArkUI_KeyCode = ArkUI_KeyCode(2100);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// F12 key
     pub const ARKUI_KEYCODE_F12: ArkUI_KeyCode = ArkUI_KeyCode(2101);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Number Lock key on numeric keypad
     pub const ARKUI_KEYCODE_NUM_LOCK: ArkUI_KeyCode = ArkUI_KeyCode(2102);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 0 on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_0: ArkUI_KeyCode = ArkUI_KeyCode(2103);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 1 on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_1: ArkUI_KeyCode = ArkUI_KeyCode(2104);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 2 on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_2: ArkUI_KeyCode = ArkUI_KeyCode(2105);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 3 on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_3: ArkUI_KeyCode = ArkUI_KeyCode(2106);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 4 on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_4: ArkUI_KeyCode = ArkUI_KeyCode(2107);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 5 on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_5: ArkUI_KeyCode = ArkUI_KeyCode(2108);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 6 on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_6: ArkUI_KeyCode = ArkUI_KeyCode(2109);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 7 on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_7: ArkUI_KeyCode = ArkUI_KeyCode(2110);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 8 on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_8: ArkUI_KeyCode = ArkUI_KeyCode(2111);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key 9 on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_9: ArkUI_KeyCode = ArkUI_KeyCode(2112);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key / on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_DIVIDE: ArkUI_KeyCode = ArkUI_KeyCode(2113);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key ) on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_MULTIPLY: ArkUI_KeyCode = ArkUI_KeyCode(2114);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key - on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_SUBTRACT: ArkUI_KeyCode = ArkUI_KeyCode(2115);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key + on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_ADD: ArkUI_KeyCode = ArkUI_KeyCode(2116);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key . on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_DOT: ArkUI_KeyCode = ArkUI_KeyCode(2117);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key , on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_COMMA: ArkUI_KeyCode = ArkUI_KeyCode(2118);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Enter key on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_ENTER: ArkUI_KeyCode = ArkUI_KeyCode(2119);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key = on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_EQUALS: ArkUI_KeyCode = ArkUI_KeyCode(2120);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key ( on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_LEFT_PAREN: ArkUI_KeyCode = ArkUI_KeyCode(2121);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyCode {
     /// Key ) on numeric keypad
     pub const ARKUI_KEYCODE_NUMPAD_RIGHT_PAREN: ArkUI_KeyCode = ArkUI_KeyCode(2122);
 }
@@ -818,28 +290,12 @@ pub struct ArkUI_KeyCode(pub ::core::ffi::c_int);
 impl ArkUI_KeyEventType {
     /// Unknown type
     pub const ARKUI_KEY_EVENT_UNKNOWN: ArkUI_KeyEventType = ArkUI_KeyEventType(-1);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyEventType {
     /// Pressing of a key
     pub const ARKUI_KEY_EVENT_DOWN: ArkUI_KeyEventType = ArkUI_KeyEventType(0);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyEventType {
     /// Release of a key
     pub const ARKUI_KEY_EVENT_UP: ArkUI_KeyEventType = ArkUI_KeyEventType(1);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyEventType {
     /// Long press of a key
     pub const ARKUI_KEY_EVENT_LONG_PRESS: ArkUI_KeyEventType = ArkUI_KeyEventType(2);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyEventType {
     /// Click of a key
     pub const ARKUI_KEY_EVENT_CLICK: ArkUI_KeyEventType = ArkUI_KeyEventType(3);
 }
@@ -857,16 +313,8 @@ pub struct ArkUI_KeyEventType(pub ::core::ffi::c_int);
 impl ArkUI_KeySourceType {
     /// Unknown type
     pub const ARKUI_KEY_SOURCE_UNKNOWN: ArkUI_KeySourceType = ArkUI_KeySourceType(0);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeySourceType {
     /// Mouse
     pub const ARKUI_KEY_SOURCE_TYPE_MOUSE: ArkUI_KeySourceType = ArkUI_KeySourceType(1);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeySourceType {
     /// Keyboard
     pub const ARKUI_KEY_SOURCE_TYPE_KEYBOARD: ArkUI_KeySourceType = ArkUI_KeySourceType(4);
 }
@@ -884,148 +332,52 @@ pub struct ArkUI_KeySourceType(pub ::core::ffi::c_uint);
 impl ArkUI_KeyIntension {
     /// Unknown intention
     pub const ARKUI_KEY_INTENSION_UNKNOWN: ArkUI_KeyIntension = ArkUI_KeyIntension(-1);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Upward
     pub const ARKUI_KEY_INTENSION_UP: ArkUI_KeyIntension = ArkUI_KeyIntension(1);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Downward
     pub const ARKUI_KEY_INTENSION_DOWN: ArkUI_KeyIntension = ArkUI_KeyIntension(2);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Leftward
     pub const ARKUI_KEY_INTENSION_LEFT: ArkUI_KeyIntension = ArkUI_KeyIntension(3);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Rightward
     pub const ARKUI_KEY_INTENSION_RIGHT: ArkUI_KeyIntension = ArkUI_KeyIntension(4);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Select
     pub const ARKUI_KEY_INTENSION_SELECT: ArkUI_KeyIntension = ArkUI_KeyIntension(5);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Escape
     pub const ARKUI_KEY_INTENSION_ESCAPE: ArkUI_KeyIntension = ArkUI_KeyIntension(6);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Back
     pub const ARKUI_KEY_INTENSION_BACK: ArkUI_KeyIntension = ArkUI_KeyIntension(7);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Forward
     pub const ARKUI_KEY_INTENSION_FORWARD: ArkUI_KeyIntension = ArkUI_KeyIntension(8);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Menu
     pub const ARKUI_KEY_INTENSION_MENU: ArkUI_KeyIntension = ArkUI_KeyIntension(9);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Home
     pub const ARKUI_KEY_INTENSION_HOME: ArkUI_KeyIntension = ArkUI_KeyIntension(10);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Page up
     pub const ARKUI_KEY_INTENSION_PAGE_UP: ArkUI_KeyIntension = ArkUI_KeyIntension(11);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Page down
     pub const ARKUI_KEY_INTENSION_PAGE_DOWN: ArkUI_KeyIntension = ArkUI_KeyIntension(12);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Zoom out
     pub const ARKUI_KEY_INTENSION_ZOOM_OUT: ArkUI_KeyIntension = ArkUI_KeyIntension(13);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Zoom in
     pub const ARKUI_KEY_INTENSION_ZOOM_IN: ArkUI_KeyIntension = ArkUI_KeyIntension(14);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Play or pause
     pub const ARKUI_KEY_INTENTION_MEDIA_PLAY_PAUSE: ArkUI_KeyIntension = ArkUI_KeyIntension(100);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Fast-forward
     pub const ARKUI_KEY_INTENTION_MEDIA_FAST_FORWARD: ArkUI_KeyIntension = ArkUI_KeyIntension(101);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Fast playback
     pub const ARKUI_KEY_INTENTION_MEDIA_FAST_PLAYBACK: ArkUI_KeyIntension = ArkUI_KeyIntension(103);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Play next
     pub const ARKUI_KEY_INTENTION_MEDIA_NEXT: ArkUI_KeyIntension = ArkUI_KeyIntension(104);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Play previous
     pub const ARKUI_KEY_INTENTION_MEDIA_PREVIOUS: ArkUI_KeyIntension = ArkUI_KeyIntension(105);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Mute
     pub const ARKUI_KEY_INTENTION_MEDIA_MUTE: ArkUI_KeyIntension = ArkUI_KeyIntension(106);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Volume up
     pub const ARKUI_KEY_INTENTION_VOLUME_UP: ArkUI_KeyIntension = ArkUI_KeyIntension(107);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Volume down
     pub const ARKUI_KEY_INTENTION_VOLUME_DOWN: ArkUI_KeyIntension = ArkUI_KeyIntension(108);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Answer a call
     pub const ARKUI_KEY_INTENTION_CALL: ArkUI_KeyIntension = ArkUI_KeyIntension(200);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl ArkUI_KeyIntension {
     /// Camera
     pub const ARKUI_KEY_INTENTION_CAMERA: ArkUI_KeyIntension = ArkUI_KeyIntension(300);
 }

--- a/components/arkui/src/native_node/native_node_ffi.rs
+++ b/components/arkui/src/native_node/native_node_ffi.rs
@@ -11,214 +11,74 @@ use crate::ui_input_event::ArkUI_UIInputEvent;
 impl ArkUI_NodeType {
     /// Custom node.
     pub const ARKUI_NODE_CUSTOM: ArkUI_NodeType = ArkUI_NodeType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Text.
     pub const ARKUI_NODE_TEXT: ArkUI_NodeType = ArkUI_NodeType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Text span.
     pub const ARKUI_NODE_SPAN: ArkUI_NodeType = ArkUI_NodeType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Image span.
     pub const ARKUI_NODE_IMAGE_SPAN: ArkUI_NodeType = ArkUI_NodeType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Image.
     pub const ARKUI_NODE_IMAGE: ArkUI_NodeType = ArkUI_NodeType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Toggle.
     pub const ARKUI_NODE_TOGGLE: ArkUI_NodeType = ArkUI_NodeType(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Loading icon.
     pub const ARKUI_NODE_LOADING_PROGRESS: ArkUI_NodeType = ArkUI_NodeType(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Single-line text input.
     pub const ARKUI_NODE_TEXT_INPUT: ArkUI_NodeType = ArkUI_NodeType(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Multi-line text input.
     pub const ARKUI_NODE_TEXT_AREA: ArkUI_NodeType = ArkUI_NodeType(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Button.
     pub const ARKUI_NODE_BUTTON: ArkUI_NodeType = ArkUI_NodeType(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Progress indicator.
     pub const ARKUI_NODE_PROGRESS: ArkUI_NodeType = ArkUI_NodeType(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Check box.
     pub const ARKUI_NODE_CHECKBOX: ArkUI_NodeType = ArkUI_NodeType(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// XComponent.
     pub const ARKUI_NODE_XCOMPONENT: ArkUI_NodeType = ArkUI_NodeType(12);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Date picker.
     pub const ARKUI_NODE_DATE_PICKER: ArkUI_NodeType = ArkUI_NodeType(13);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Time picker.
     pub const ARKUI_NODE_TIME_PICKER: ArkUI_NodeType = ArkUI_NodeType(14);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Text picker.
     pub const ARKUI_NODE_TEXT_PICKER: ArkUI_NodeType = ArkUI_NodeType(15);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Calendar picker.
     pub const ARKUI_NODE_CALENDAR_PICKER: ArkUI_NodeType = ArkUI_NodeType(16);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Slider.
     pub const ARKUI_NODE_SLIDER: ArkUI_NodeType = ArkUI_NodeType(17);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Radio
     pub const ARKUI_NODE_RADIO: ArkUI_NodeType = ArkUI_NodeType(18);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Image animator.
     pub const ARKUI_NODE_IMAGE_ANIMATOR: ArkUI_NodeType = ArkUI_NodeType(19);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Stack container.
     pub const ARKUI_NODE_STACK: ArkUI_NodeType = ArkUI_NodeType(1000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Swiper.
     pub const ARKUI_NODE_SWIPER: ArkUI_NodeType = ArkUI_NodeType(1001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Scrolling container.
     pub const ARKUI_NODE_SCROLL: ArkUI_NodeType = ArkUI_NodeType(1002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// List.
     pub const ARKUI_NODE_LIST: ArkUI_NodeType = ArkUI_NodeType(1003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// List item.
     pub const ARKUI_NODE_LIST_ITEM: ArkUI_NodeType = ArkUI_NodeType(1004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// List item group.
     pub const ARKUI_NODE_LIST_ITEM_GROUP: ArkUI_NodeType = ArkUI_NodeType(1005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Column container.
     pub const ARKUI_NODE_COLUMN: ArkUI_NodeType = ArkUI_NodeType(1006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Row container.
     pub const ARKUI_NODE_ROW: ArkUI_NodeType = ArkUI_NodeType(1007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Flex container.
     pub const ARKUI_NODE_FLEX: ArkUI_NodeType = ArkUI_NodeType(1008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Refresh component.
     pub const ARKUI_NODE_REFRESH: ArkUI_NodeType = ArkUI_NodeType(1009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Water flow container.
     pub const ARKUI_NODE_WATER_FLOW: ArkUI_NodeType = ArkUI_NodeType(1010);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Water flow item.
     pub const ARKUI_NODE_FLOW_ITEM: ArkUI_NodeType = ArkUI_NodeType(1011);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Relative layout component.
     pub const ARKUI_NODE_RELATIVE_CONTAINER: ArkUI_NodeType = ArkUI_NodeType(1012);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Grid.
     pub const ARKUI_NODE_GRID: ArkUI_NodeType = ArkUI_NodeType(1013);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Grid item.
     pub const ARKUI_NODE_GRID_ITEM: ArkUI_NodeType = ArkUI_NodeType(1014);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeType {
     /// Custom span.
     pub const ARKUI_NODE_CUSTOM_SPAN: ArkUI_NodeType = ArkUI_NodeType(1015);
 }
@@ -264,10 +124,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: width, in vp.
     pub const NODE_WIDTH: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the height attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -280,10 +136,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: height, in vp.
     pub const NODE_HEIGHT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the background color attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -296,10 +148,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: background color. The value is in 0xARGB format. For example, 0xFFFF0000 indicates red.
     pub const NODE_BACKGROUND_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the background image attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -321,10 +169,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object: The parameter type is [`ArkUI_DrawableDescriptor`].
     pub const NODE_BACKGROUND_IMAGE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the padding attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// There are two formats of [`ArkUI_AttributeItem`] for setting the attribute value:
@@ -355,10 +199,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: left padding, in vp.
     pub const NODE_PADDING: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the component ID attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -371,10 +211,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: component ID.
     pub const NODE_ID: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the interactivity attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -387,10 +223,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: The value <b>1</b> means that the component can interact with users, and <b>0</b> means the opposite.
     pub const NODE_ENABLED: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the margin attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// There are two formats of [`ArkUI_AttributeItem`] for setting the attribute value:
@@ -421,10 +253,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: left margin, in vp.
     pub const NODE_MARGIN: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the translate attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -445,10 +273,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[2].f32: distance to translate along the z-axis, in vp.
     pub const NODE_TRANSLATE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the scale attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -465,10 +289,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[1].f32: scale factor along the y-axis.
     pub const NODE_SCALE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the rotate attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -498,10 +318,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[4].f32: line of sight, that is, the distance from the viewpoint to the z=0 plane, in vp.
     pub const NODE_ROTATE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the brightness attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -514,10 +330,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: brightness value.
     pub const NODE_BRIGHTNESS: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the saturation attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -530,10 +342,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: saturation value.
     pub const NODE_SATURATION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(12);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the blur attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -548,10 +356,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].f32: blur radius. The larger the fuzzy radius, the more blurred the image. If the value is <b>0</b>,
     /// the image is not blurred. The unit is vp.
     pub const NODE_BLUR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(13);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the gradient attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -593,10 +397,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// size: number of colors.
     pub const NODE_LINEAR_GRADIENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(14);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the alignment attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -610,10 +410,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: alignment mode. The data type is [`ArkUI_Alignment`].
     pub const NODE_ALIGNMENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(15);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the opacity attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -626,10 +422,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: opacity value. The value ranges from 0 to 1.
     pub const NODE_OPACITY: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(16);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the border width attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -656,10 +448,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: width of the left border.
     pub const NODE_BORDER_WIDTH: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the border corner radius attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -686,10 +474,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: radius of the lower right corner.
     pub const NODE_BORDER_RADIUS: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(18);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the border color attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -716,10 +500,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].u32: color of the left border, in 0xARGB format, for example, <b>0xFFFF11FF</b>.
     pub const NODE_BORDER_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(19);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the border line style attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -751,10 +531,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].i32: line style of the left border.
     pub const NODE_BORDER_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(20);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the z-index attribute for the stack sequence.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -768,10 +544,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: z-index value.
     pub const NODE_Z_INDEX: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(21);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the visibility attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -786,10 +558,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether to show or hide the component. The parameter type is [`ArkUI_Visibility`].
     /// The default value is <b>ARKUI_VISIBILITY_VISIBLE</b>.
     pub const NODE_VISIBILITY: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(22);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the clipping and masking attribute, which can be set, reset, and obtained as required through
     /// APIs.
     ///
@@ -805,10 +573,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether to clip the component based on the parent container bounds.
     /// The value <b>1</b> means to clip the component, and <b>0</b> means the opposite.
     pub const NODE_CLIP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(23);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the clipping region on the component.
     /// This attribute can be set and obtained as required through APIs.
     ///
@@ -917,10 +681,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: command for drawing the path.
     pub const NODE_CLIP_SHAPE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(24);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the transform attribute, which can be used to translate, rotate, and scale images.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -934,10 +694,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0...15].f32: 16 floating-point numbers.
     pub const NODE_TRANSFORM: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(25);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the hit test behavior attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -952,10 +708,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: hit test mode. The parameter type is [`ArkUI_HitTestMode`].
     /// The default value is <b>ARKUI_HIT_TEST_MODE_DEFAULT</b>.
     pub const NODE_HIT_TEST_BEHAVIOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(26);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the offset attribute, which specifies the offset of the component's upper left corner relative
     /// to the parent container's. This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -973,10 +725,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[1].f32: Y coordinate.
     pub const NODE_POSITION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(27);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the shadow attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -989,10 +737,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: shadow effect. The parameter type is [`ArkUI_ShadowStyle`].
     pub const NODE_SHADOW: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(28);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the custom shadow effect. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -1033,10 +777,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[6].u32: whether to fill the shadow. The value <b>1</b> means to fill the shadow, and <b>0</b>
     /// means the opposite.
     pub const NODE_CUSTOM_SHADOW: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(29);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the background image width and height.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1054,10 +794,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[1].f32: height of the image, in vp.
     pub const NODE_BACKGROUND_IMAGE_SIZE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(30);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the background image size.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1072,10 +808,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: size of the background image. The value is an enum of [`ArkUI_ImageSize`].
     pub const NODE_BACKGROUND_IMAGE_SIZE_WITH_STYLE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(31);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the background blur attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -1108,10 +840,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[5].f32: end boundary of grayscale blur.
     pub const NODE_BACKGROUND_BLUR_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(32);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the transform center attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -1144,10 +872,6 @@ impl ArkUI_NodeAttributeType {
     /// Note: If the coordinate is expressed in a number that represents a percentage, the attribute obtaining API
     /// returns the calculated value in vp.
     pub const NODE_TRANSFORM_CENTER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(33);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the transition opacity attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -1184,10 +908,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[6].f32: animation playback speed.
     pub const NODE_OPACITY_TRANSITION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(34);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the transition rotation attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -1242,10 +962,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[10].f32: animation playback speed.
     pub const NODE_ROTATE_TRANSITION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(35);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the transition scaling attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -1292,10 +1008,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[8].f32: animation playback speed.
     pub const NODE_SCALE_TRANSITION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(36);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the transition translation attribute.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1343,10 +1055,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// value[8].f32: animation playback speed.
     pub const NODE_TRANSLATE_TRANSITION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(37);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the slide-in and slide-out of the component from the screen edge during transition.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1384,10 +1092,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[6].f32: animation playback speed.
     pub const NODE_MOVE_TRANSITION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(38);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the focus attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -1399,10 +1103,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: The parameter type is 1 or 0.
     pub const NODE_FOCUSABLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(39);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the default focus attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -1414,10 +1114,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// value[0].i32: The parameter type is 1 or 0.
     pub const NODE_DEFAULT_FOCUS: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(40);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the touch target attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -1445,10 +1141,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .data[4...].f32: Multiple touch targets can be set. The sequence of the parameters is the same as the preceding.
     pub const NODE_RESPONSE_REGION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(41);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the overlay attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -1476,10 +1168,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[2].f32: offset of the overlay relative to the upper left corner of itself on the y-axis, in vp.
     pub const NODE_OVERLAY: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(42);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the sweep gradient effect.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1533,10 +1221,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// size: number of colors.
     pub const NODE_SWEEP_GRADIENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(43);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the radial gradient effect.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1582,10 +1266,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// size: number of colors.
     pub const NODE_RADIAL_GRADIENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(44);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Adds a mask of the specified shape to the component.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1761,10 +1441,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].u32: color of the progress indicator.
     pub const NODE_MASK: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(45);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Blends the component's background with the content of the component's child node.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1786,10 +1462,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[1].i32: how the specified blend mode is applied. The parameter type is [`ArkUI_BlendApplyType`].
     /// The default value is <b>ARKUI_BLEND_APPLY_TYPE_FAST</b>.
     pub const NODE_BLEND_MODE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(46);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the direction of the main axis.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1807,10 +1479,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// The parameter type is [`ArkUI_Direction`]. The default value is <b>ARKUI_DIRECTION_AUTO</b>.
     pub const NODE_DIRECTION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(47);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the size constraints.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1836,10 +1504,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: maximum height, in vp.
     pub const NODE_CONSTRAINT_SIZE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(48);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the grayscale effect.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1854,10 +1518,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: grayscale conversion ratio. The value ranges from 0 to 1.
     pub const NODE_GRAY_SCALE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(49);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Inverts the image.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1872,10 +1532,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: image inversion ratio. The value ranges from 0 to 1.
     pub const NODE_INVERT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(50);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the sepia conversion ratio.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1890,10 +1546,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: sepia conversion ratio. The value ranges from 0 to 1.
     pub const NODE_SEPIA: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(51);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the contrast attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -1907,10 +1559,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: contrast. Value range: [0, 10).
     pub const NODE_CONTRAST: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(52);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the foreground color attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// There are two formats of [`ArkUI_AttributeItem`] for setting the attribute value:
@@ -1925,10 +1573,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: color value, in 0xARGB format.
     pub const NODE_FOREGROUND_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(53);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the offset of the component's child relative to the component.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1946,10 +1590,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[1].f32 : offset along the y-axis, in vp.
     pub const NODE_OFFSET: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(54);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the anchor for locating the component's child.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1967,10 +1607,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[1].f32: Y coordinate of the anchor, in vp.
     pub const NODE_MARK_ANCHOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(55);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the position of the background image in the component, that is, the coordinates relative to
     /// the upper left corner of the component. This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -1988,10 +1624,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[1].f32: position along the y-axis, in px.
     pub const NODE_BACKGROUND_IMAGE_POSITION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(56);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the alignment rules in the relative container.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -2005,10 +1637,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object: Use the [`ArkUI_AlignmentRuleOption`] object as the component’s alignment rule.
     pub const NODE_ALIGN_RULES: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(57);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the alignment mode of the child components along the cross axis of the parent container.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -2026,10 +1654,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// The parameter type is [`ArkUI_ItemAlignment`]. The default value is <b>ARKUI_ITEM_ALIGNMENT_AUTO</b>.
     pub const NODE_ALIGN_SELF: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(58);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the percentage of the parent container's remaining space that is allocated to the component.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -2043,10 +1667,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: percentage of the parent container's remaining space that is allocated to the component.
     pub const NODE_FLEX_GROW: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(59);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the percentage of the parent container's shrink size that is allocated to the component.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -2060,10 +1680,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: percentage of the parent container's shrink size that is allocated to the component.
     pub const NODE_FLEX_SHRINK: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(60);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the base size of the component.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -2077,10 +1693,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: percentage of the parent container's remaining space that is allocated to the component.
     pub const NODE_FLEX_BASIS: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(61);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the accessibility group. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2098,10 +1710,6 @@ impl ArkUI_NodeAttributeType {
     /// In this case, the accessibility service will no longer be available for the content of its child components.
     /// The value is <b>1</b> or <b>0</b>.
     pub const NODE_ACCESSIBILITY_GROUP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(62);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the accessibility text. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2113,10 +1721,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: accessibility text.
     pub const NODE_ACCESSIBILITY_TEXT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(63);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the accessibility service model. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2128,10 +1732,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: accessibility service model. The parameter type is [`ArkUI_AccessibilityMode`].
     pub const NODE_ACCESSIBILITY_MODE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(64);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the accessibility description.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -2144,10 +1744,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: accessibility description.
     pub const NODE_ACCESSIBILITY_DESCRIPTION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(65);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the focused state. This attribute can be set and obtained as required through APIs.
     ///
     /// **Note:** Setting the parameter to <b>0</b> shifts focus from the currently focused component on the current level
@@ -2162,10 +1758,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: The parameter type is 1 or 0.
     pub const NODE_FOCUS_STATUS: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(66);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the aspect ratio attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2178,10 +1770,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: aspect ratio of the component, in width/height format.
     pub const NODE_ASPECT_RATIO: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(67);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the weight of the component within its row, column, or flex container for proportional
     /// distribution of available space within the container.
     /// This attribute can be set, reset, and obtained as required through APIs.
@@ -2196,10 +1784,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: weight of the component along the main axis.
     pub const NODE_LAYOUT_WEIGHT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(68);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the display priority for the component in the row, column, or flex (single-line) container.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -2213,10 +1797,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: display priority of the component in the container.
     pub const NODE_DISPLAY_PRIORITY: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(69);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the thickness of an element's outline.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2241,10 +1821,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: thickness of the bottom outline.
     pub const NODE_OUTLINE_WIDTH: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(70);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the width attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2257,10 +1833,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: width, in percentage.
     pub const NODE_WIDTH_PERCENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(71);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the height attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2273,10 +1845,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: height, in percentage.
     pub const NODE_HEIGHT_PERCENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(72);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the padding attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// There are two formats of [`ArkUI_AttributeItem`] for setting the attribute value:
@@ -2307,10 +1875,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: left padding, in percentage.
     pub const NODE_PADDING_PERCENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(73);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the margin attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// There are two formats of [`ArkUI_AttributeItem`] for setting the attribute value:
@@ -2341,10 +1905,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: left margin, in percentage.
     pub const NODE_MARGIN_PERCENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(74);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// The implicit shared element transition within the component supports attribute setting,
     /// attribute reset, and attribute acquisition interfaces.
     ///
@@ -2376,10 +1936,6 @@ impl ArkUI_NodeAttributeType {
     /// The same ID can only be bound to two components and they are in/out roles of different types.
     /// Multiple components cannot be bound to the same id.
     pub const NODE_GEOMETRY_TRANSITION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(75);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// specifies the parameters of the chain formed by this component as the chain head,
     /// and supports attribute setting, attribute reset and attribute acquisition interfaces.
     ///
@@ -2398,10 +1954,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[1].i32: Chain style. Enum [`ArkUI_RelativeLayoutChainStyle`].
     pub const NODE_RELATIVE_LAYOUT_CHAIN_MODE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(76);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the component content filling method in the process of width and height animation,
     /// support property setting, property reset, property acquisition interface.
     ///
@@ -2415,10 +1967,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32 Content filling mode [`ArkUI_RenderFit`].
     pub const NODE_RENDER_FIT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(77);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// External stroke color properties, support property setting,
     /// property reset and property acquisition interface.
     ///
@@ -2446,10 +1994,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].u32: Set the left border color, denoted by 0xargb, such as 0xFFFF11FF.
     pub const NODE_OUTLINE_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(78);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the height and width dimensions, support property setting,
     /// property reset and property acquisition interface.
     ///
@@ -2467,10 +2011,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[1].f32: Height value, unit is vp;
     pub const NODE_SIZE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(79);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set whether the current component and child component are
     /// rendered off the screen first and then fused with the parent control,
     /// supporting property setting, property reset and property acquisition.
@@ -2484,10 +2024,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: The parameter type is 1 or 0.
     pub const NODE_RENDER_GROUP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(80);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Add color overlay effect to components, support property setting,
     /// property reset and property acquisition interface.
     ///
@@ -2501,10 +2037,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: The color of the overlay is represented by 0xargb, such as 0xFFFF11FF.
     pub const NODE_COLOR_BLEND: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(81);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Provide content ambiguity capability for the current component,
     /// support property setting, property reset, property acquisition interface.
     ///
@@ -2546,10 +2078,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[5].f32 It is a gray-level fuzzy parameter. The value range is [0,127].
     pub const NODE_FOREGROUND_BLUR_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(82);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines layout rect attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2567,10 +2095,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[2].i32: width of the component.
     /// .value[3].i32: height of the component.
     pub const NODE_LAYOUT_RECT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(83);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Whether the current component supports click-to-focus capability,
     /// which can be set, reset, and obtained as required through APIs.
     ///
@@ -2583,10 +2107,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: The parameter type is 1 or 0.
     pub const NODE_FOCUS_ON_TOUCH: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(84);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the border width attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2613,10 +2133,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: width of the left border, in percentage.
     pub const NODE_BORDER_WIDTH_PERCENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(85);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the border corner radius attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2643,20 +2159,12 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: radius of the lower right corner, in percentage.
     pub const NODE_BORDER_RADIUS_PERCENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(86);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Accessible ID, which can be obtained as required through APIs.
     ///
     /// Format of the return value [`ArkUI_AttributeItem`]:
     ///
     /// .value[0].i32：Accessible ID。
     pub const NODE_ACCESSIBILITY_ID: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(87);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Define accessible actions, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2669,10 +2177,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32：accessible action types，and uses the [`ArkUI_AccessibilityActionType`] enumeration value.
     pub const NODE_ACCESSIBILITY_ACTIONS: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(88);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Define accessible role, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2685,10 +2189,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32：accessible role type，and uses the [`ArkUI_NodeType`] enumeration value.
     pub const NODE_ACCESSIBILITY_ROLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(89);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Define accessible state, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2701,10 +2201,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object：the parameter type is [`ArkUI_AccessibilityState`].
     pub const NODE_ACCESSIBILITY_STATE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(90);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Define accessible value, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2717,10 +2213,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object：the parameter type is [`ArkUI_AccessibilityValue`].
     pub const NODE_ACCESSIBILITY_VALUE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(91);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// defines control components to extend their security zones,
     /// supporting property setting, property reset, and property fetching.
     ///
@@ -2743,10 +2235,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[1].u32: indicates the direction to extend the security zone.
     /// .
     pub const NODE_EXPAND_SAFE_AREA: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(92);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the visible area ratio (visible area/total area of the component) threshold for invoking the
     /// visible area change event of the component.
     ///
@@ -2759,10 +2247,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[...].f32: threshold array.
     pub const NODE_VISIBLE_AREA_CHANGE_RATIO: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(93);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the transition effect when the component is inserted or deleted.
     /// This attribute can be set, and obtained as required through APIs.
     ///
@@ -2776,10 +2260,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object: transition effect. The parameter type is [`ArkUI_TransitionEffect`].
     pub const NODE_TRANSITION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(94);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the component ID.
     /// This attribute can be obtained through APIs.
     ///
@@ -2787,10 +2267,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: component ID.
     pub const NODE_UNIQUE_ID: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(95);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the current component system focus box style.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2807,10 +2283,6 @@ impl ArkUI_NodeAttributeType {
     ///
     ///
     pub const NODE_FOCUS_BOX: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(96);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the moving distance limit for the component-bound tap gesture.
     /// This attribute can be set as required through APIs.
     ///
@@ -2818,10 +2290,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: allowed moving distance of a finger, in vp.
     pub const NODE_CLICK_DISTANCE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(97);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether the focus can be placed on this component.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -2839,10 +2307,6 @@ impl ArkUI_NodeAttributeType {
     #[cfg(feature = "api-14")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
     pub const NODE_TAB_STOP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(98);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text content attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2855,10 +2319,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: text content.
     pub const NODE_TEXT_CONTENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font color attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2871,10 +2331,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: font color value, in 0xARGB format.
     pub const NODE_FONT_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font size attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2887,10 +2343,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: font size, in fp.
     pub const NODE_FONT_SIZE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font style attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2903,10 +2355,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: font style [`ArkUI_FontStyle`].
     pub const NODE_FONT_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font weight attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2919,10 +2367,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: font weight [`ArkUI_FontWeight`].
     pub const NODE_FONT_WEIGHT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text line height attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2935,10 +2379,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: line height, in fp.
     pub const NODE_TEXT_LINE_HEIGHT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text decoration style and color.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -2961,10 +2401,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[2].i32: text decoration style [`ArkUI_TextDecorationStyle`].
     pub const NODE_TEXT_DECORATION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text case attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2977,10 +2413,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: text case.
     pub const NODE_TEXT_CASE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the letter spacing attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -2993,10 +2425,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: letter spacing, in fp.
     pub const NODE_TEXT_LETTER_SPACING: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the maximum number of lines in the text.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3010,10 +2438,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: maximum number of lines in the text.
     pub const NODE_TEXT_MAX_LINES: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Horizontal alignment mode of the text.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3027,10 +2451,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: horizontal alignment mode of the text. The value is an enum of [`ArkUI_TextAlignment`].
     pub const NODE_TEXT_ALIGN: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1010);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text overflow attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3043,10 +2463,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: display mode when the text is too long. [`ArkUI_TextOverflow`]
     pub const NODE_TEXT_OVERFLOW: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1011);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font family attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3058,10 +2474,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: fonts, separated by commas (,).
     pub const NODE_FONT_FAMILY: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1012);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the copy option attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3074,10 +2486,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: copy option [`ArkUI_CopyOptions.`]
     pub const NODE_TEXT_COPY_OPTION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1013);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text baseline offset attribute
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3091,10 +2499,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: baseline offset, in fp.
     pub const NODE_TEXT_BASELINE_OFFSET: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1014);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text shadow attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3123,10 +2527,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[4].f32: offset of the shadow along the y-axis, in vp.
     pub const NODE_TEXT_TEXT_SHADOW: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1015);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the minimum font size attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3138,10 +2538,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: minimum font size, in fp.
     pub const NODE_TEXT_MIN_FONT_SIZE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1016);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the maximum font size attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3153,10 +2549,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: maximum font size, in fp.
     pub const NODE_TEXT_MAX_FONT_SIZE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1017);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text style attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3184,10 +2576,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[2].i32: font style. The parameter type is [`ArkUI_FontStyle`].
     /// The default value is <b>ARKUI_FONT_STYLE_NORMAL</b>.
     pub const NODE_TEXT_FONT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1018);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines how the adaptive height is determined for the text.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3203,10 +2591,6 @@ impl ArkUI_NodeAttributeType {
     /// The parameter type is [`ArkUI_TextHeightAdaptivePolicy`]
     pub const NODE_TEXT_HEIGHT_ADAPTIVE_POLICY: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1019);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the indentation of the first line.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3220,10 +2604,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: indentation of the first line.
     pub const NODE_TEXT_INDENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1020);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the line break rule. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3236,10 +2616,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: The parameter type is [`ArkUI_WordBreak`].
     pub const NODE_TEXT_WORD_BREAK: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1021);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the ellipsis position. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3252,10 +2628,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: The parameter type is [`ArkUI_EllipsisMode`].
     pub const NODE_TEXT_ELLIPSIS_MODE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1022);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text line spacing attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3268,10 +2640,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: line spacing, in fp.
     pub const NODE_TEXT_LINE_SPACING: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1023);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     ///  Set the text feature effect and the NODE_FONT_FEATURE attribute,
     /// NODE_FONT_FEATURE is the advanced typesetting capability of OpenType
     /// Features such as ligatures and equal-width digits are generally used in customized fonts.
@@ -3296,10 +2664,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string indicates the content of the text feature. Multiple text features are separated by commas (,).
     pub const NODE_FONT_FEATURE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1024);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Setting Enable Text Recognition.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3313,10 +2677,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32：Enable Text Recognition
     pub const NODE_TEXT_ENABLE_DATA_DETECTOR: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1025);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the text recognition configuration.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3330,10 +2690,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0...].i32：Array of entity types, parameter types[`ArkUI_TextDataDetectorType`]。
     pub const NODE_TEXT_ENABLE_DATA_DETECTOR_CONFIG: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1026);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the background color of the selected text.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3348,10 +2704,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].u32: color value, in 0xARGB format.
     pub const NODE_TEXT_SELECTED_BACKGROUND_COLOR: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1027);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// The text component uses a formatted string object to set text content properties,
     /// and supports property setting, property reset, and property acquisition interfaces.
     ///
@@ -3366,10 +2718,6 @@ impl ArkUI_NodeAttributeType {
     /// .object indicates ArkUI_StyledString formatted string data. The parameter type is [`ArkUI_StyledString`].
     pub const NODE_TEXT_CONTENT_WITH_STYLED_STRING: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1028);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether to center text vertically in the text component.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3382,10 +2730,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: whether to center text vertically.
     pub const NODE_TEXT_HALF_LEADING: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1029);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text content attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3398,10 +2742,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: content of the text span.
     pub const NODE_SPAN_CONTENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(2000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text background style.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3436,10 +2776,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[4].f32: radius of the lower right corner, in vp.
     pub const NODE_SPAN_TEXT_BACKGROUND_STYLE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(2001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text baseline offset attribute
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3453,10 +2789,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: baseline offset, in fp.
     pub const NODE_SPAN_BASELINE_OFFSET: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(2002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the image source of the image span.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3474,10 +2806,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object: The parameter type is [`ArkUI_DrawableDescriptor`].
     pub const NODE_IMAGE_SPAN_SRC: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(3000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the alignment mode of the image with the text.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3494,10 +2822,6 @@ impl ArkUI_NodeAttributeType {
     /// The value is an enum of [`ArkUI_ImageSpanAlignment`].
     pub const NODE_IMAGE_SPAN_VERTICAL_ALIGNMENT: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(3001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the placeholder image source.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3515,10 +2839,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object: The parameter type is [`ArkUI_DrawableDescriptor`].
     pub const NODE_IMAGE_SPAN_ALT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(3002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the baseline offset attribute of the <b>ImageSpan</b> component.
     /// This attribute can be set, reset, and obtained as required through APIs.
     /// A positive value means an upward offset, while a negative value means a downward offset.
@@ -3542,10 +2862,6 @@ impl ArkUI_NodeAttributeType {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
     pub const NODE_IMAGE_SPAN_BASELINE_OFFSET: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(3003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the image source of the <Image> component.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3563,10 +2879,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object: The parameter type is [`ArkUI_DrawableDescriptor`].
     pub const NODE_IMAGE_SRC: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines how the image is resized to fit its container.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3580,10 +2892,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: how the image is resized to fit its container. The value is an enum of [`ArkUI_ObjectFit`].
     pub const NODE_IMAGE_OBJECT_FIT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the interpolation effect of the image.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3597,10 +2905,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: interpolation effect of the image. The value is an enum of [`ArkUI_ImageInterpolation`].
     pub const NODE_IMAGE_INTERPOLATION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines how the image is repeated.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3614,10 +2918,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: how the image is repeated. The value is an enum of [`ArkUI_ImageRepeat`].
     pub const NODE_IMAGE_OBJECT_REPEAT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the color filter of the image.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3639,10 +2939,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object: the pointer to OH_Drawing_ColorFilter.
     pub const NODE_IMAGE_COLOR_FILTER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the auto resize attribute, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3655,10 +2951,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32 : whether to resize the image source.
     pub const NODE_IMAGE_AUTO_RESIZE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the placeholder image source.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3676,10 +2968,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object: The parameter type is [`ArkUI_DrawableDescriptor`].
     pub const NODE_IMAGE_ALT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether the image is draggable.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3693,10 +2981,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: whether the image is draggable.
     pub const NODE_IMAGE_DRAGGABLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the image rendering mode. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3709,10 +2993,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: The parameter type is [`ArkUI_ImageRenderMode`].
     pub const NODE_IMAGE_RENDER_MODE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether the image display size follows the image source size.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3726,10 +3006,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: wheter to follow, true means to follow.
     pub const NODE_IMAGE_FIT_ORIGINAL_SIZE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the fill color of the swiper.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3743,10 +3019,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: fill color, in 0xARGB format.
     pub const NODE_IMAGE_FILL_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4010);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the resizable image options.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3771,10 +3043,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: width of the bottom edge. The unit is vp.
     pub const NODE_IMAGE_RESIZABLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(4011);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the color of the component when it is selected.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3788,10 +3056,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: background color, in 0xARGB format.
     pub const NODE_TOGGLE_SELECTED_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(5000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the color of the circular slider for the component of the switch type.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3806,10 +3070,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].u32: color of the circular slider, in 0xARGB format.
     pub const NODE_TOGGLE_SWITCH_POINT_COLOR: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(5001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the toggle switch value. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -3822,10 +3082,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: whether to enable the toggle.
     pub const NODE_TOGGLE_VALUE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(5002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the color of the component when it is deselected.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3839,10 +3095,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: background color, in 0xARGB format.
     pub const NODE_TOGGLE_UNSELECTED_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(5003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the foreground color of the loading progress bar.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3856,10 +3108,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: foreground color, in 0xARGB format.
     pub const NODE_LOADING_PROGRESS_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(6000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to show the loading animation for the <LoadingProgress> component.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3875,10 +3123,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: The value <b>1</b> means to show the loading animation, and <b>0</b> means the opposite.
     pub const NODE_LOADING_PROGRESS_ENABLE_LOADING: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(6001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the default placeholder text of the single-line text box.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3892,10 +3136,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: default placeholder text.
     pub const NODE_TEXT_INPUT_PLACEHOLDER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the default text content of the single-line text box.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3909,10 +3149,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: default text content.
     pub const NODE_TEXT_INPUT_TEXT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the caret color attribute.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3926,10 +3162,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: caret color, in 0xARGB format.
     pub const NODE_TEXT_INPUT_CARET_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the caret style attribute.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3943,10 +3175,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: caret width, in vp.
     pub const NODE_TEXT_INPUT_CARET_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the underline attribute of the single-line text box.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3962,10 +3190,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: The value <b>1</b> means to show an underline, and <b>0</b> means the opposite.
     pub const NODE_TEXT_INPUT_SHOW_UNDERLINE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the maximum number of characters in the text input.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3979,10 +3203,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: maximum number of characters in the text input.
     pub const NODE_TEXT_INPUT_MAX_LENGTH: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the type of the Enter key.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -3997,10 +3217,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: type of the Enter key[`ArkUI_EnterKeyType`].
     pub const NODE_TEXT_INPUT_ENTER_KEY_TYPE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the placeholder text color.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4015,10 +3231,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].u32: color value, in 0xARGB format.
     pub const NODE_TEXT_INPUT_PLACEHOLDER_COLOR: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the placeholder text font.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4048,10 +3260,6 @@ impl ArkUI_NodeAttributeType {
     /// .string: font family. Multiple font families are separated by commas (,).
     pub const NODE_TEXT_INPUT_PLACEHOLDER_FONT: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to enable the input method when the component obtains focus.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4069,10 +3277,6 @@ impl ArkUI_NodeAttributeType {
     /// and <b>0</b> means the opposite.
     pub const NODE_TEXT_INPUT_ENABLE_KEYBOARD_ON_FOCUS: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text box type. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4086,10 +3290,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: text box type [`ArkUI_TextInputType`].
     pub const NODE_TEXT_INPUT_TYPE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7010);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the background color of the selected text.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4104,10 +3304,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].u32: color value, in 0xARGB format.
     pub const NODE_TEXT_INPUT_SELECTED_BACKGROUND_COLOR: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7011);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to display the password icon at the end of the password text box.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4124,10 +3320,6 @@ impl ArkUI_NodeAttributeType {
     /// and <b>0</b> means the opposite.
     pub const NODE_TEXT_INPUT_SHOW_PASSWORD_ICON: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7012);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the editable state for the single-line text box.
     /// This attribute can be set as required through APIs.
     ///
@@ -4142,10 +3334,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether to remain in the editable state. The value <b>true</b> means to remain in the editable
     /// state, and <b>false</b> means to exit the editable state.
     pub const NODE_TEXT_INPUT_EDITING: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7013);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the style of the cancel button on the right of the single-line text box.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4173,10 +3361,6 @@ impl ArkUI_NodeAttributeType {
     /// .string: button icon image source.
     pub const NODE_TEXT_INPUT_CANCEL_BUTTON: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7014);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the text selection area, which will be highlighted.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4195,10 +3379,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[1].i32: end position of the text selection.
     pub const NODE_TEXT_INPUT_TEXT_SELECTION: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7015);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the color of the text underline when it is enabled.
     ///
     /// The default underline color configured for the theme is <b>'0x33182431'</b>.
@@ -4231,10 +3411,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[3].u32: color of the underline applied to the text when it is disabled. The value is in 0xARGB format.
     pub const NODE_TEXT_INPUT_UNDERLINE_COLOR: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7016);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether to enable autofill.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4248,10 +3424,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether to enable autofill.
     pub const NODE_TEXT_INPUT_ENABLE_AUTO_FILL: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7017);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the autofill type.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4264,10 +3436,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: autofill type. The parameter type is [`ArkUI_TextInputContentType`].
     pub const NODE_TEXT_INPUT_CONTENT_TYPE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7018);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the rules for generating passwords. When autofill is used, these rules are transparently
     /// transmitted to Password Vault for generating a new password.
     ///
@@ -4282,10 +3450,6 @@ impl ArkUI_NodeAttributeType {
     /// .string: rules for generating passwords.
     pub const NODE_TEXT_INPUT_PASSWORD_RULES: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7019);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether to select all text in the initial state. The inline mode is not supported.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4298,10 +3462,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: whether to select all text in the initial state.
     pub const NODE_TEXT_INPUT_SELECT_ALL: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7020);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the regular expression for input filtering.
     /// Only inputs that comply with the regular expression can be displayed.
     /// Other inputs are filtered out. The specified regular expression can match single characters,
@@ -4317,10 +3477,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: regular expression.
     pub const NODE_TEXT_INPUT_INPUT_FILTER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7021);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the text box to the default style or inline input style.
     ///
     /// For the inline input style, only <b>InputType.Normal</b> is supported.
@@ -4335,10 +3491,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: text input style. The parameter type is [`ArkUI_TextInputStyle`].
     pub const NODE_TEXT_INPUT_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7022);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets or obtains the caret position.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4357,10 +3509,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[2].f32: Y coordinate of the caret relative to the text box.
     pub const NODE_TEXT_INPUT_CARET_OFFSET: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7023);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Obtains the position of the edited text area relative to the component and its size.
     ///
     /// Format of the return value [`ArkUI_AttributeItem`]:
@@ -4373,10 +3521,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: content height.
     pub const NODE_TEXT_INPUT_CONTENT_RECT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7024);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Obtains the number of lines of the edited text.
     ///
     /// Format of the return value [`ArkUI_AttributeItem`]:
@@ -4384,10 +3528,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: number of lines of the edited text.
     pub const NODE_TEXT_INPUT_CONTENT_LINE_COUNT: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7025);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether to hide the text selection menu when the text box is long-pressed, double-click, or
     /// right-clicked. This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4404,10 +3544,6 @@ impl ArkUI_NodeAttributeType {
     /// right-clicked.
     pub const NODE_TEXT_INPUT_SELECTION_MENU_HIDDEN: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7026);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether the text box loses focus after the Enter key is pressed to submit information.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4421,10 +3557,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether the text box loses focus.
     pub const NODE_TEXT_INPUT_BLUR_ON_SUBMIT: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7027);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set up a custom keyboard.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4442,10 +3574,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32：Set whether the custom keyboard supports the avoidance function.
     pub const NODE_TEXT_INPUT_CUSTOM_KEYBOARD: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7028);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the line break rule. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4458,10 +3586,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: The parameter type is [`ArkUI_WordBreak`].
     pub const NODE_TEXT_INPUT_WORD_BREAK: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(7029);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether the keyboard pops up when the input box gains focus.
     /// It supports property setting, property reset and property acquisition interfaces.
     ///
@@ -4476,10 +3600,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: Whether to pop up the keyboard.
     pub const NODE_TEXT_INPUT_SHOW_KEYBOARD_ON_FOCUS: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7030);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// When this property is set, the height of the textInput component is calculated using this property.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4493,10 +3613,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: the value of numberOfLines.
     pub const NODE_TEXT_INPUT_NUMBER_OF_LINES: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(7031);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the default placeholder text for the multi-line text box.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4510,10 +3626,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: default placeholder text.
     pub const NODE_TEXT_AREA_PLACEHOLDER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the default text content for the multi-line text box.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4527,10 +3639,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: default text content.
     pub const NODE_TEXT_AREA_TEXT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the maximum number of characters in the text input.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4544,10 +3652,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: maximum number of characters in the text input.
     pub const NODE_TEXT_AREA_MAX_LENGTH: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the placeholder text color.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4562,10 +3666,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].u32: color value, in 0xARGB format.
     pub const NODE_TEXT_AREA_PLACEHOLDER_COLOR: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the placeholder text font.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4592,10 +3692,6 @@ impl ArkUI_NodeAttributeType {
     /// .string: font family. Multiple font families are separated by commas (,).
     pub const NODE_TEXT_AREA_PLACEHOLDER_FONT: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the caret color attribute.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4609,10 +3705,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: background color, in 0xARGB format.
     pub const NODE_TEXT_AREA_CARET_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the editable state for the multi-line text box.
     /// This attribute can be set as required through APIs.
     ///
@@ -4629,10 +3721,6 @@ impl ArkUI_NodeAttributeType {
     /// state, and <b>false</b> means to exit the editable state.
     ///
     pub const NODE_TEXT_AREA_EDITING: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the text box type. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4646,10 +3734,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: text box type [`ArkUI_TextAreaType`].
     pub const NODE_TEXT_AREA_TYPE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the counter settings. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4675,10 +3759,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[2].i32: whether to highlight the border when the number of entered characters reaches the maximum.
     /// The default value is <b>true</b>.
     pub const NODE_TEXT_AREA_SHOW_COUNTER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether to hide the text selection menu when the text box is long-pressed, double-click,
     /// or right-clicked. This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4695,10 +3775,6 @@ impl ArkUI_NodeAttributeType {
     /// or right-clicked.
     pub const NODE_TEXT_AREA_SELECTION_MENU_HIDDEN: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether the multi-line text box loses focus after the Enter key is pressed to submit information.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4712,10 +3788,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether the text box loses focus.
     pub const NODE_TEXT_AREA_BLUR_ON_SUBMIT: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8010);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the regular expression for input filtering.
     /// Only inputs that comply with the regular expression can be displayed.
     /// Other inputs are filtered out. The specified regular expression can match single characters,
@@ -4731,10 +3803,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: regular expression.
     pub const NODE_TEXT_AREA_INPUT_FILTER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8011);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the background color of the selected text.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4749,10 +3817,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].u32: color value, in 0xARGB format.
     pub const NODE_TEXT_AREA_SELECTED_BACKGROUND_COLOR: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8012);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the type of the Enter key.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4767,10 +3831,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: type of the Enter key[`ArkUI_EnterKeyType`].
     pub const NODE_TEXT_AREA_ENTER_KEY_TYPE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8013);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to enable the input method when the component obtains focus.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4788,10 +3848,6 @@ impl ArkUI_NodeAttributeType {
     /// and <b>0</b> means the opposite.
     pub const NODE_TEXT_AREA_ENABLE_KEYBOARD_ON_FOCUS: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8014);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to enable the input method when the component obtains focus.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4808,10 +3864,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: The value <b>1</b> means to enable the input method when the component obtains focus,
     /// and <b>0</b> means the opposite.
     pub const NODE_TEXT_AREA_CARET_OFFSET: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8015);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Obtains the position of the edited text area relative to the component and its size.
     ///
     /// Format of the return value [`ArkUI_AttributeItem`]:
@@ -4824,10 +3876,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: content height.
     pub const NODE_TEXT_AREA_CONTENT_RECT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8016);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Obtains the number of lines of the edited text.
     ///
     /// Format of the return value [`ArkUI_AttributeItem`]:
@@ -4835,10 +3883,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: number of lines of the edited text.
     pub const NODE_TEXT_AREA_CONTENT_LINE_COUNT: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8017);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the text selection area, which will be highlighted.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4857,10 +3901,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[1].i32: end position of the text selection.
     pub const NODE_TEXT_AREA_TEXT_SELECTION: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8018);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether to enable autofill.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4874,10 +3914,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether to enable autofill.
     pub const NODE_TEXT_AREA_ENABLE_AUTO_FILL: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8019);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the autofill type.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4890,10 +3926,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: autofill type. The parameter type is [`ArkUI_TextInputContentType`].
     pub const NODE_TEXT_AREA_CONTENT_TYPE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(8020);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether the keyboard pops up when the input box gains focus.
     /// It supports property setting, property reset and property acquisition interfaces.
     ///
@@ -4908,10 +3940,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: Whether to pop up the keyboard.
     pub const NODE_TEXT_AREA_SHOW_KEYBOARD_ON_FOCUS: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8021);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// When this property is set, the height of the textArea component is calculated using this property.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4925,10 +3953,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: Set the value of numberOfLines
     pub const NODE_TEXT_AREA_NUMBER_OF_LINES: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(8022);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the button text content. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4941,10 +3965,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: default text content.
     pub const NODE_BUTTON_LABEL: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(9000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the button type. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -4959,10 +3979,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: button type. The parameter type is [`ArkUI_ButtonType`].
     /// The default value is <b>ARKUI_BUTTON_TYPE_CAPSULE</b>.
     pub const NODE_BUTTON_TYPE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(9001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the current value of the progress indicator.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4976,10 +3992,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: current value of the progress indicator.
     pub const NODE_PROGRESS_VALUE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(10000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the total value of the progress indicator.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -4993,10 +4005,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: total value of the progress indicator.
     pub const NODE_PROGRESS_TOTAL: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(10001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the color for the progress value on the progress indicator.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5010,10 +4018,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: color value, in 0xARGB format.
     pub const NODE_PROGRESS_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(10002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the type of the progress indicator.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5028,10 +4032,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: type of the progress indicator [`ArkUI_ProgressType`].
     pub const NODE_PROGRESS_TYPE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(10003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether the check box is selected.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5046,10 +4046,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: The value <b>1</b> means that the check box is selected, and <b>0</b> means the opposite.
     pub const NODE_CHECKBOX_SELECT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(11000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the color of the check box when it is selected.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5063,10 +4059,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: color of the check box when it is selected, in 0xARGB format, for example, <b>0xFF1122FF</b>.
     pub const NODE_CHECKBOX_SELECT_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(11001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the border color of the check box when it is not selected.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5081,10 +4073,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].u32: border color, in 0xARGB format, for example, <b>0xFF1122FF</b>.
     pub const NODE_CHECKBOX_UNSELECT_COLOR: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(11002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the internal icon style of the check box.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5106,10 +4094,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[2].f32: stroke width of the internal mark, in vp. The default value is <b>2</b>.
     pub const NODE_CHECKBOX_MARK: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(11003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the shape of the check box.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5123,10 +4107,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: component shape. The parameter type is [`ArkUI_CheckboxShape`].
     pub const NODE_CHECKBOX_SHAPE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(11004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the ID of the <b><XComponent></b> component.
     /// This attribute can be set and obtained as required through APIs.
     ///
@@ -5140,10 +4120,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: component ID.
     pub const NODE_XCOMPONENT_ID: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(12000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the type of the <b><XComponent></b> component.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5157,10 +4133,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: type [`ArkUI_XComponentType`].
     pub const NODE_XCOMPONENT_TYPE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(12001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the width and height of the <b><XComponent></b> component.
     /// This attribute can be set and obtained as required through APIs.
     ///
@@ -5179,10 +4151,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[1].u32: height, in px.
     pub const NODE_XCOMPONENT_SURFACE_SIZE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(12002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to display the lunar calendar in the date picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5196,10 +4164,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: whether to display the lunar calendar in the date picker.
     pub const NODE_DATE_PICKER_LUNAR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(13000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the start date of the date picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5213,10 +4177,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: date.
     pub const NODE_DATE_PICKER_START: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(13001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the end date of the date picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5230,10 +4190,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: date.
     pub const NODE_DATE_PICKER_END: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(13002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the selected date of the date picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5247,10 +4203,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: date.
     pub const NODE_DATE_PICKER_SELECTED: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(13003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font color, font size, and font weight for the top and bottom items in the date picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5289,10 +4241,6 @@ impl ArkUI_NodeAttributeType {
     /// Example: "#ff182431;14;normal;Arial,HarmonyOS Sans;normal".
     pub const NODE_DATE_PICKER_DISAPPEAR_TEXT_STYLE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(13004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font color, font size, and font weight of all items except the top, bottom, and selected
     /// items in the date picker. This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5330,10 +4278,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// Example: "#ff182431;14;normal;Arial,HarmonyOS Sans;normal".
     pub const NODE_DATE_PICKER_TEXT_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(13005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font color, font size, and font weight of the selected item in the date picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5372,10 +4316,6 @@ impl ArkUI_NodeAttributeType {
     /// Example: "#ff182431;14;normal;Arial,HarmonyOS Sans;normal".
     pub const NODE_DATE_PICKER_SELECTED_TEXT_STYLE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(13006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the time of the selected item. in the timer picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5389,10 +4329,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: time.
     pub const NODE_TIME_PICKER_SELECTED: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(14000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether the display time is in 24-hour format.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5407,10 +4343,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether the display time is in 24-hour format.
     pub const NODE_TIME_PICKER_USE_MILITARY_TIME: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(14001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font color, font size, and font weight for the top and bottom items in the time picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5449,10 +4381,6 @@ impl ArkUI_NodeAttributeType {
     /// Example: "#ff182431;14;normal;Arial,HarmonyOS Sans;normal".
     pub const NODE_TIME_PICKER_DISAPPEAR_TEXT_STYLE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(14002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font color, font size, and font weight of all items except the top, bottom, and selected items
     /// in the time picker. This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5490,10 +4418,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// Example: "#ff182431;14;normal;Arial,HarmonyOS Sans;normal".
     pub const NODE_TIME_PICKER_TEXT_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(14003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font color, font size, and font weight of the selected item in the time picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5532,10 +4456,6 @@ impl ArkUI_NodeAttributeType {
     /// Example: "#ff182431;14;normal;Arial,HarmonyOS Sans;normal".
     pub const NODE_TIME_PICKER_SELECTED_TEXT_STYLE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(14004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the data selection range of the text picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5577,10 +4497,6 @@ impl ArkUI_NodeAttributeType {
     /// 2: multi-column interconnected picker. The output structure is [`ARKUI_TextPickerCascadeRangeContent`].
     pub const NODE_TEXT_PICKER_OPTION_RANGE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(15000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the index of the default selected item in the data selection range of the text picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5595,10 +4511,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].u32: index. If there are multiple index values, add them one by one.
     pub const NODE_TEXT_PICKER_OPTION_SELECTED: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(15001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the value of the default selected item in the text picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5615,10 +4527,6 @@ impl ArkUI_NodeAttributeType {
     /// separate them with semicolons (;).
     pub const NODE_TEXT_PICKER_OPTION_VALUE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(15002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font color, font size, and font weight for the top and bottom items in the text picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5657,10 +4565,6 @@ impl ArkUI_NodeAttributeType {
     /// Example: "#ff182431;14;normal;Arial,HarmonyOS Sans;normal".
     pub const NODE_TEXT_PICKER_DISAPPEAR_TEXT_STYLE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(15003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font color, font size, and font weight for all items except the top, bottom, and selected
     /// items in the text picker. This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5698,10 +4602,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// Example: "#ff182431;14;normal;Arial,HarmonyOS Sans;normal".
     pub const NODE_TEXT_PICKER_TEXT_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(15004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font color, font size, and font weight for the selected item in the text picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5740,10 +4640,6 @@ impl ArkUI_NodeAttributeType {
     /// Example: "#ff182431;14;normal;Arial,HarmonyOS Sans;normal".
     pub const NODE_TEXT_PICKER_SELECTED_TEXT_STYLE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(15005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the index of the default selected item in the data selection range of the text picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5752,10 +4648,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0...].i32: index of the default item in the data selection range.
     pub const NODE_TEXT_PICKER_SELECTED_INDEX: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(15006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to support scroll looping for the text picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5771,10 +4663,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// value[0].i32: The value <b>1</b> means to support scroll looping, and <b>0</b> means the opposite.
     pub const NODE_TEXT_PICKER_CAN_LOOP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(15007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the height of each item in the picker. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -5789,10 +4677,6 @@ impl ArkUI_NodeAttributeType {
     /// value[0].f32: item height, in vp.
     pub const NODE_TEXT_PICKER_DEFAULT_PICKER_ITEM_HEIGHT: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(15008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the style of the background in the selected state of the calendar picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5813,10 +4697,6 @@ impl ArkUI_NodeAttributeType {
     /// greater than 16, the background is a circle.
     pub const NODE_CALENDAR_PICKER_HINT_RADIUS: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(16000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the date of the selected item in the calendar picker.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5839,10 +4719,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[2].u32: day of the selected date.
     pub const NODE_CALENDAR_PICKER_SELECTED_DATE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(16001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines how the calendar picker is aligned with the entry component.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -5869,10 +4745,6 @@ impl ArkUI_NodeAttributeType {
     /// the specified alignment mode.
     pub const NODE_CALENDAR_PICKER_EDGE_ALIGNMENT: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(16002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the font color, font size, and font weight in the entry area of the calendar picker.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -5894,10 +4766,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[2].i32: font weight of the entry area. The parameter type is [`ArkUI_FontWeight`].
     pub const NODE_CALENDAR_PICKER_TEXT_STYLE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(16003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the color of the slider. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -5909,10 +4777,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: color of the slider, in 0xARGB format, for example, <b>0xFF1122FF</b>.
     pub const NODE_SLIDER_BLOCK_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the background color of the slider. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -5926,10 +4790,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: background color, in 0xARGB format, for example, <b>0xFF1122FF</b>.
     pub const NODE_SLIDER_TRACK_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the color of the selected part of the slider track. This attribute can be set, reset, and obtained
     /// as required through APIs.
     ///
@@ -5943,10 +4803,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].u32: color of the selected part of the slider track, in 0xARGB format, for example, <b>0xFF1122FF</b>.
     pub const NODE_SLIDER_SELECTED_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether to display the stepping value. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -5962,10 +4818,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether to display the stepping value. The value <b>1</b> means to display the stepping value,
     /// and <b>0</b> (default value) means the opposite.
     pub const NODE_SLIDER_SHOW_STEPS: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the slider shape, which can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -6078,10 +4930,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: command for drawing the path.
     pub const NODE_SLIDER_BLOCK_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the current value of the slider. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -6095,10 +4943,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: current value.
     pub const NODE_SLIDER_VALUE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the minimum value of the slider. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -6112,10 +4956,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: minimum value.
     pub const NODE_SLIDER_MIN_VALUE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the maximum value of the slider. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -6129,10 +4969,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: maximum value.
     pub const NODE_SLIDER_MAX_VALUE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the step of the slider. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -6145,10 +4981,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: step. The value range is [0.01, 100].
     pub const NODE_SLIDER_STEP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether the slider moves horizontally or vertically. This attribute can be set, reset, and
     /// obtained as required through APIs.
     ///
@@ -6163,10 +4995,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: whether the slider moves horizontally or vertically.
     pub const NODE_SLIDER_DIRECTION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether the slider values are reversed. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -6182,10 +5010,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether the slider values are reversed. The value <b>1</b> means that the slider values are
     /// reversed, and <b>0</b> means the opposite.
     pub const NODE_SLIDER_REVERSE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17010);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the style of the slider thumb and track. This attribute can be set, reset, and obtained
     /// as required through APIs.
     ///
@@ -6199,10 +5023,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: style of the slider thumb and track. The parameter type is [`ArkUI_SliderStyle`].
     pub const NODE_SLIDER_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17011);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the track thickness of the slider.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6218,10 +5038,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: track thickness of the slider, in vp.
     pub const NODE_SLIDER_TRACK_THICKNESS: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(17012);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the selection status of an option button. Attribute setting,
     /// attribute resetting, and attribute obtaining are supported.
     /// Attribute setting method [`ArkUI_AttributeItem`] Parameter format:
@@ -6231,10 +5047,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: selection status of an option button.
     pub const NODE_RADIO_CHECKED: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(18000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the styles of the selected and deselected states of the option button.
     /// The attribute setting, attribute resetting, and attribute obtaining are supported.
     /// Attribute setting method [`ArkUI_AttributeItem`] Parameter format:
@@ -6265,10 +5077,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// The type is 0xARGB, and the default value is 0xFFFFFFF.
     pub const NODE_RADIO_STYLE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(18001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the value of the current radio.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6282,10 +5090,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: radio value.
     pub const NODE_RADIO_VALUE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(18002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the group name of the current Radio group, only one radio of the same group can be selected.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6299,10 +5103,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: name of the group to which the current option box belongs.
     pub const NODE_RADIO_GROUP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(18003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the image frames for the image animator. Dynamic updates is not supported.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6320,10 +5120,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object: array of the images, the type is [`ArkUI_ImageAnimatorFrameInfo`] array.
     pub const NODE_IMAGE_ANIMATOR_IMAGES: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(19000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the playback status of the animation for the image animator.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6336,10 +5132,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: the playback status of the animation, the type is [`ArkUI_AnimationStatus`].
     pub const NODE_IMAGE_ANIMATOR_STATE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(19001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the playback duration for the image animator. When the duration is 0, no image is played.
     /// The value change takes effect only at the beginning of the next cycle.
     /// When a separate duration is set in images, the setting of this attribute is invalid.
@@ -6355,10 +5147,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: the playback duration, the unit is ms.
     pub const NODE_IMAGE_ANIMATOR_DURATION: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(19002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the playback direction for the image animator.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6373,10 +5161,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: the playback direction. 0 indicates that images are played from the first one to the last one,
     /// and 1 indicates that images are played from the last one to the first one.
     pub const NODE_IMAGE_ANIMATOR_REVERSE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(19003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set whether the image size is the same as the component size.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6395,10 +5179,6 @@ impl ArkUI_NodeAttributeType {
     /// 0 indicates the image size is customized.
     pub const NODE_IMAGE_ANIMATOR_FIXED_SIZE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(19004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the status before and after execution of the animation in the current playback direction.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6414,10 +5194,6 @@ impl ArkUI_NodeAttributeType {
     /// the type is {ArkUI_AnimationFillMode}.
     pub const NODE_IMAGE_ANIMATOR_FILL_MODE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(19005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the number of times that the animation is played.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6431,10 +5207,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: the number of times that the animation is played.
     pub const NODE_IMAGE_ANIMATOR_ITERATION: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(19006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the alignment mode of the child components in the container. This attribute can be set, reset,
     /// and obtained as required through APIs.
     ///
@@ -6449,10 +5221,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: alignment mode. The data type is [`ArkUI_Alignment`].
     pub const NODE_STACK_ALIGN_CONTENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1000000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the scrollbar status. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -6467,10 +5235,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: scrollbar status. The parameter type is [`ArkUI_ScrollBarDisplayMode`].
     pub const NODE_SCROLL_BAR_DISPLAY_MODE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1002000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the width of the scrollbar. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -6484,10 +5248,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: width of the scrollbar, in vp.
     pub const NODE_SCROLL_BAR_WIDTH: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the color of the scrollbar. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -6501,10 +5261,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .data[0].u32: color of the scrollbar, in 0xARGB format.
     pub const NODE_SCROLL_BAR_COLOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the scroll direction. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -6519,10 +5275,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: scroll direction. The parameter type is [`ArkUI_ScrollDirection`].
     pub const NODE_SCROLL_SCROLL_DIRECTION: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1002003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the effect used at the edges of the component when the boundary of the scrollable content is
     /// reached. This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6545,10 +5297,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[1].i32: whether to enable the scroll effect when the component content size is smaller than the component
     /// itself. Optional. The value <b>1</b> means to enable the scroll effect, and <b>0</b> means the opposite.
     pub const NODE_SCROLL_EDGE_EFFECT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to support scroll gestures. When this attribute is set to <b>false</b>, scrolling by
     /// finger or mouse is not supported, but the scroll controller API is not affected.
     ///
@@ -6563,10 +5311,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether to support scroll gestures.
     pub const NODE_SCROLL_ENABLE_SCROLL_INTERACTION: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1002005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the friction coefficient. It applies only to gestures in the scrolling area, and it affects only
     /// indirectly the scroll chaining during the inertial scrolling process.
     ///
@@ -6581,10 +5325,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: friction coefficient.
     pub const NODE_SCROLL_FRICTION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the scroll snapping mode. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -6622,10 +5362,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[3...].f32: snap points for the <b><Scroll></b> component. Each snap point defines the offset from an edge
     /// to which the <b><Scroll></b> component can scroll.
     pub const NODE_SCROLL_SNAP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the nested scrolling options. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -6647,10 +5383,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[1].i32: nested scrolling option when the component scrolls backward.
     /// The parameter type is [`ArkUI_ScrollNestedMode`].
     pub const NODE_SCROLL_NESTED_SCROLL: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the specified position to scroll to. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -6678,10 +5410,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[1].f32: vertical scrolling offset, in vp.
     pub const NODE_SCROLL_OFFSET: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the edge position to scroll to. This attribute can be set and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -6695,10 +5423,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether the container at the edge position. The value <b>-1</b> means that the container is not
     /// at the edge position. If the container is at the edge position, the parameter type is [`ArkUI_ScrollEdge`].
     pub const NODE_SCROLL_EDGE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002010);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to enable the swipe-to-turn-pages feature. This attribute can be set, reset, and obtained
     /// as required through APIs.
     ///
@@ -6717,10 +5441,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: whether to enable the swipe-to-turn-pages feature.
     pub const NODE_SCROLL_ENABLE_PAGING: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002011);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Scroll to the next or previous page.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -6730,10 +5450,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[1]?.i32 Indicates whether to enable animation. Value 1 indicates enable and 0 indicates disable.
     pub const NODE_SCROLL_PAGE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002012);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Scroll a specified distance.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -6742,10 +5458,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[1].f32: Vertical scrolling distance in vp;
     pub const NODE_SCROLL_BY: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002013);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Performs inertial scrolling based on the initial velocity passed in.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -6760,10 +5472,6 @@ impl ArkUI_NodeAttributeType {
     #[cfg(feature = "api-13")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
     pub const NODE_SCROLL_FLING: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002014);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the fading effect for the edges of scrollable components.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -6781,10 +5489,6 @@ impl ArkUI_NodeAttributeType {
     #[cfg(feature = "api-14")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
     pub const NODE_SCROLL_FADING_EDGE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002015);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Obtains the total size of all child components when fully expanded in the scrollable component.
     ///
     /// Format of the return value [`ArkUI_AttributeItem`]:
@@ -6805,10 +5509,6 @@ impl ArkUI_NodeAttributeType {
     #[cfg(feature = "api-14")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
     pub const NODE_SCROLL_SIZE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1002016);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the direction in which the list items are arranged. This attribute can be set, reset, and
     /// obtained as required through APIs.
     ///
@@ -6823,10 +5523,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: direction in which the list items are arranged. The parameter type is [`ArkUI_Axis`].
     pub const NODE_LIST_DIRECTION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1003000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to pin the header to the top or the footer to the bottom in the <b><ListItemGroup></b>
     /// component. This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6844,10 +5540,6 @@ impl ArkUI_NodeAttributeType {
     /// component. It is used together with the <b><ListItemGroup></b> component. The parameter type is
     /// [`ArkUI_StickyStyle`].
     pub const NODE_LIST_STICKY: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1003001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the spacing between list items. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -6861,20 +5553,12 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: spacing between list items along the main axis.
     pub const NODE_LIST_SPACE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1003002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the list adapter. The attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
     ///
     /// .object: [`ArkUI_NodeAdapter`] object as the adapter.
     pub const NODE_LIST_NODE_ADAPTER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1003003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the number of cached items in the list adapter.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6882,10 +5566,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: number of cached items in the list adapter.
     pub const NODE_LIST_CACHED_COUNT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1003004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Scroll to the specified index.
     ///
     /// When activating the smooth animation, all items passed through will be loaded and layout calculated, which can
@@ -6903,10 +5583,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[2]?.i32：Specify the alignment of the sliding element with the current container,The parameter type is
     /// [`ArkUI_ScrollAlignment`], default value is ARKUI_SCROLL_ALIGNMENT_START.
     pub const NODE_LIST_SCROLL_TO_INDEX: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1003005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the alignment mode of list items along the cross axis when the cross-axis width of the list is
     /// greater than the cross-axis width of list items multiplied by the value of lanes.
     /// This attribute can be set, reset, and obtained as required through APIs.
@@ -6923,10 +5599,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: alignment mode of list items along the cross axis.
     /// The parameter type is [`ArkUI_ListItemAlignment`].
     pub const NODE_LIST_ALIGN_LIST_ITEM: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1003006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the default spindle size for the List subcomponent.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -6940,10 +5612,6 @@ impl ArkUI_NodeAttributeType {
     /// .object: The parameter format is [`ArkUI-ListChildrenMainSize`]
     pub const NODE_LIST_CHILDREN_MAIN_SIZE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1003007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the index value of the item displayed at the start of the viewport
     /// when the current List is first loaded.This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6959,10 +5627,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: index value of the item displayed at
     /// the start of the viewport when the current List is loaded for the first time. Default value: 0.
     pub const NODE_LIST_INITIAL_INDEX: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1003008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// sets the ListItem splitter style. By default, there is no splitter.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -6988,10 +5652,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[3].f32: the distance between the divider and the end of the side of the list (unit: vp).
     pub const NODE_LIST_DIVIDER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1003009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to enable loop playback for the swiper.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7007,10 +5667,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether to enable loop playback. The value <b>1</b> means to enable loop playback, and <b>0</b>
     /// means the opposite. The default value is <b>1</b>.
     pub const NODE_SWIPER_LOOP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to enable automatic playback for child component switching in the swiper.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7026,10 +5682,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether to enable automatic playback for child component switching. The value <b>1</b> means
     /// to enable automatic playback, and <b>0</b> means the opposite. The default value is <b>0</b>.
     pub const NODE_SWIPER_AUTO_PLAY: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to enable the navigation point indicator for the swiper. This attribute can be set,
     /// reset, and obtained as required through APIs.
     ///
@@ -7046,10 +5698,6 @@ impl ArkUI_NodeAttributeType {
     /// navigation point indicator, and <b>0</b> means the opposite. The default value is <b>1</b>.
     pub const NODE_SWIPER_SHOW_INDICATOR: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1001002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the interval for automatic playback. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -7063,10 +5711,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: interval for automatic playback, in milliseconds.
     pub const NODE_SWIPER_INTERVAL: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether vertical swiping is used for the swiper. This attribute can be set, reset, and obtained
     /// as required through APIs.
     ///
@@ -7082,10 +5726,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether vertical swiping is used. The value <b>1</b> means that vertical swiping is used, and
     /// <b>0</b> means the opposite. The default value is <b>0</b>.
     pub const NODE_SWIPER_VERTICAL: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the duration of the animation for switching child components. This attribute can be set, reset,
     /// and obtained as required through APIs.
     ///
@@ -7101,10 +5741,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].f32: duration of the animation for switching child components, in milliseconds. The default value is
     /// <b>400</b>.
     pub const NODE_SWIPER_DURATION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the animation curve for the swiper. This attribute can be set, reset, and obtained as required
     /// through APIs.
     ///
@@ -7120,10 +5756,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: animation curve. The parameter type is [`ArkUI_AnimationCurve`].
     /// The default value is <b>ARKUI_CURVE_LINEAR</b>.
     pub const NODE_SWIPER_CURVE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the spacing between child components in the swiper.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7137,10 +5769,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: spacing between child components.
     pub const NODE_SWIPER_ITEM_SPACE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the index of the child component currently displayed in the swiper.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7154,10 +5782,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: index value of the child component.
     pub const NODE_SWIPER_INDEX: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the number of elements to display per page.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7171,10 +5795,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: index value of the child component.
     pub const NODE_SWIPER_DISPLAY_COUNT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to disable the swipe feature.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7190,10 +5810,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: whether to disable the swipe feature. The value <b>1</b> means to disable the swipe
     /// feature, and <b>0</b> means the opposite. The default value is <b>0</b>.
     pub const NODE_SWIPER_DISABLE_SWIPE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001010);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines whether to show the arrow when the mouse pointer hovers over the navigation point indicator.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7214,10 +5830,6 @@ impl ArkUI_NodeAttributeType {
     /// The default value is <b>ARKUI_SWIPER_ARROW_HIDE</b>.
     pub const NODE_SWIPER_SHOW_DISPLAY_ARROW: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1001011);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the effect used at the edges of the swiper when the boundary of the scrollable content is reached.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7236,20 +5848,12 @@ impl ArkUI_NodeAttributeType {
     /// The parameter type is [`ArkUI_EdgeEffect`].
     pub const NODE_SWIPER_EDGE_EFFECT_MODE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1001012);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the swiper adapter. The attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
     ///
     /// .object: [`ArkUI_NodeAdapter`] object as the adapter.
     pub const NODE_SWIPER_NODE_ADAPTER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001013);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the number of cached items in the swiper adapter.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7257,10 +5861,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: number of cached items in the swiper adapter.
     pub const NODE_SWIPER_CACHED_COUNT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001014);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the front margin of the wiper.
     /// The attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7278,10 +5878,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[1].i32: whether to ignore blank areas. The value <b>1</b> means to ignore blank areas, and <b>0</b> means
     /// the opposite.
     pub const NODE_SWIPER_PREV_MARGIN: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001015);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the back margin of the wiper.
     /// The attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7299,10 +5895,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[1].i32: whether to ignore blank areas. The value <b>1</b> means to ignore blank areas, and <b>0</b> means
     /// the opposite.
     pub const NODE_SWIPER_NEXT_MARGIN: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001016);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the navigation indicator type of the swiper.
     /// The attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7318,10 +5910,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object: The parameter type is [`ArkUI_SwiperIndicator`].
     pub const NODE_SWIPER_INDICATOR: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001017);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the nested scrolling mode for the Swiper component and parent component.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -7338,10 +5926,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32：Nested scrolling patterns for Swiper components and parent components. The parameter type is
     /// [`ArkUI_SwiperNestedScrollMode`]
     pub const NODE_SWIPER_NESTED_SCROLL: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1001018);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the switcher component to flip to the specified page.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -7352,10 +5936,6 @@ impl ArkUI_NodeAttributeType {
     /// effect, 0 indicates no active effect, default value is 0。
     pub const NODE_SWIPER_SWIPE_TO_INDEX: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1001019);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set to disable component navigation point interaction function。
     ///
     /// Property setting method parameter [`ArkUI-AttributeItem`] format:
@@ -7368,10 +5948,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32：Set to disable component navigation point interaction.
     pub const NODE_SWIPER_INDICATOR_INTERACTIVE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1001020);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the delineation component of the ListItem, supporting property settings, property resets, and
     /// property acquisition interfaces.
     ///
@@ -7386,10 +5962,6 @@ impl ArkUI_NodeAttributeType {
     /// .object: Construct using the [`ArkUI_ListitemSwipeActionOption`] object.
     pub const NODE_LIST_ITEM_SWIPE_ACTION: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1004000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the header of the list item group.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7404,10 +5976,6 @@ impl ArkUI_NodeAttributeType {
     /// .object: [`ArkUI_NodeHandle`] object to be used as the header of the list item group.
     pub const NODE_LIST_ITEM_GROUP_SET_HEADER: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1005000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the footer of the list item group. This attribute can be set, reset, and obtained as
     /// required through APIs.
     ///
@@ -7422,10 +5990,6 @@ impl ArkUI_NodeAttributeType {
     /// .object: [`ArkUI_NodeHandle`] object to be used as the footer of the list item group.
     pub const NODE_LIST_ITEM_GROUP_SET_FOOTER: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1005001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the style of the divider for the list items. This attribute can be set, reset, and obtained
     /// as required through APIs.
     ///
@@ -7454,10 +6018,6 @@ impl ArkUI_NodeAttributeType {
     ///
     pub const NODE_LIST_ITEM_GROUP_SET_DIVIDER: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1005002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the default spindle size for the ListItem Group subcomponent.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -7471,10 +6031,6 @@ impl ArkUI_NodeAttributeType {
     /// .object: The parameter format is [`ArkUI-ListChildrenMainSize`]
     pub const NODE_LIST_ITEM_GROUP_CHILDREN_MAIN_SIZE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1005003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the horizontal alignment mode of child components in the column.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7492,10 +6048,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: horizontal alignment mode of child components.
     /// The parameter type is [`ArkUI_HorizontalAlignment`].
     pub const NODE_COLUMN_ALIGN_ITEMS: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1006000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the vertical alignment mode of child components in the column.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7512,10 +6064,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: vertical alignment mode of child components. The parameter type is [`ArkUI_FlexAlignment`].
     pub const NODE_COLUMN_JUSTIFY_CONTENT: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1006001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the vertical alignment mode of child components in the row.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7533,10 +6081,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: vertical alignment mode of child components.
     /// The parameter type is [`ArkUI_VerticalAlignment`].
     pub const NODE_ROW_ALIGN_ITEMS: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1007000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the horizontal alignment mode of child components in the row.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7554,10 +6098,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: horizontal alignment mode of child components.
     /// The parameter type is [`ArkUI_FlexAlignment`].
     pub const NODE_ROW_JUSTIFY_CONTENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1007001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the flex attribute. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -7591,10 +6131,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[4].i32: alignment mode along the cross axis for multi-line content.
     pub const NODE_FLEX_OPTION: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1008000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether the component is being refreshed.
     /// This attribute can be set and obtained as required through APIs.
     ///
@@ -7607,10 +6143,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].i32: The parameter type is 1 or 0.
     pub const NODE_REFRESH_REFRESHING: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1009000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the custom content in the pull-down area.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7618,10 +6150,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .object: The parameter type is [`ArkUI_NodeHandle`].
     pub const NODE_REFRESH_CONTENT: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1009001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the pull-down hand coefficient.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7635,10 +6163,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].f32：Pull-down hand coefficient, valid value between 0 and 1.
     pub const NODE_REFRESH_PULL_DOWN_RATIO: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1009002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the pull-down offset that initiates a refresh.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7651,10 +6175,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: pull-down offset, in vp. The default value is <b>64vp</b>.
     pub const NODE_REFRESH_OFFSET: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1009003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets whether to initiate a refresh when the pull-down distance exceeds the value of <b>refreshOffset</b>.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7670,10 +6190,6 @@ impl ArkUI_NodeAttributeType {
     /// <b>0</b> means the opposite.
     pub const NODE_REFRESH_PULL_TO_REFRESH: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1009004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the main axis direction of the <b><WaterFlow></b> component layout.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7687,10 +6203,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: main axis direction. The parameter type is [`ArkUI_FlexDirection`].
     pub const NODE_WATER_FLOW_LAYOUT_DIRECTION: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1010000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the number of columns in the water flow layout. If this parameter is not set, one column is used
     /// by default. This attribute can be set, reset, and obtained as required through APIs.
     /// For example, <b>'1fr 1fr 2fr'</b> indicates three columns, with the first column taking up 1/4 of the parent
@@ -7711,10 +6223,6 @@ impl ArkUI_NodeAttributeType {
     /// .string: number of columns in the layout.
     pub const NODE_WATER_FLOW_COLUMN_TEMPLATE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1010001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the number of rows in the water flow layout. If this parameter is not set, one row is used
     /// by default. This attribute can be set, reset, and obtained as required through APIs.
     /// For example, <b>'1fr 1fr 2fr'</b> indicates three rows, with the first row taking up 1/4 of the parent
@@ -7735,10 +6243,6 @@ impl ArkUI_NodeAttributeType {
     /// .string: number of rows in the layout.
     pub const NODE_WATER_FLOW_ROW_TEMPLATE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1010002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the gap between columns.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7753,10 +6257,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].f32: gap between columns, in vp.
     pub const NODE_WATER_FLOW_COLUMN_GAP: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1010003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the gap between rows.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7770,10 +6270,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: gap between lines, in vp.
     pub const NODE_WATER_FLOW_ROW_GAP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1010004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the water flow section configuration.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7790,10 +6286,6 @@ impl ArkUI_NodeAttributeType {
     /// .object: [`ArkUI_WaterFlowSectionOption`] object.
     pub const NODE_WATER_FLOW_SECTION_OPTION: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1010005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the water flow adapter. The attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -7801,10 +6293,6 @@ impl ArkUI_NodeAttributeType {
     /// .object: [`ArkUI_NodeAdapter`] object as the adapter.
     pub const NODE_WATER_FLOW_NODE_ADAPTER: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1010006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the number of cached items in the water flow adapter.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7813,20 +6301,12 @@ impl ArkUI_NodeAttributeType {
     /// .value[0].i32: number of cached items in the water flowadapter.
     pub const NODE_WATER_FLOW_CACHED_COUNT: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1010007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the custom display component at the end of the waterfall flow component.
     ///
     /// Attribute setting method [`ArkUI_AttributeItem`] parameter format:
     ///
     /// .object: Parameter type [`ArkUI_NodeHandle`].
     pub const NODE_WATER_FLOW_FOOTER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1010008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Scroll to the specified index.
     ///
     /// When activating the smooth animation, all items passed through will be loaded and layout calculated, which can
@@ -7845,10 +6325,6 @@ impl ArkUI_NodeAttributeType {
     /// [`ArkUI_ScrollAlignment`]. Default value is </b>ARKUI_SCROLL_ALIGNMENT_START</b>。
     pub const NODE_WATER_FLOW_SCROLL_TO_INDEX: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1010009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the size constraints to apply to water flow items.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -7875,10 +6351,6 @@ impl ArkUI_NodeAttributeType {
     /// .value[3].f32: maximum height, in vp.
     pub const NODE_WATER_FLOW_ITEM_CONSTRAINT_SIZE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1010010);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Set the auxiliary line in the RelativeContaine container, supporting property setting,
     /// property reset and property acquisition interfaces.
     ///
@@ -7893,10 +6365,6 @@ impl ArkUI_NodeAttributeType {
     /// .object: Auxiliary lines within the RelativeContaine container:
     pub const NODE_RELATIVE_CONTAINER_GUIDE_LINE: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1012000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the barrier within the RelativeContaine container and supports property setting,
     /// property reset and property acquisition interfaces.
     ///
@@ -7911,10 +6379,6 @@ impl ArkUI_NodeAttributeType {
     /// .object: Barrier within the RelativeContaine container:
     pub const NODE_RELATIVE_CONTAINER_BARRIER: ArkUI_NodeAttributeType =
         ArkUI_NodeAttributeType(1012001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the number of columns in the grid layout. If this parameter is not set, one column is used
     /// by default. This attribute can be set, reset, and obtained as required through APIs.
     /// For example, <b>'1fr 1fr 2fr'</b> indicates three columns, with the first column taking up 1/4 of the parent
@@ -7934,10 +6398,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: number of columns in the layout.
     pub const NODE_GRID_COLUMN_TEMPLATE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1013000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the number of rows in the grid layout. If this parameter is not set, one row is used
     /// by default. This attribute can be set, reset, and obtained as required through APIs.
     /// For example, <b>'1fr 1fr 2fr'</b> indicates three rows, with the first row taking up 1/4 of the parent
@@ -7957,10 +6417,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .string: number of rows in the layout.
     pub const NODE_GRID_ROW_TEMPLATE: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1013001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the gap between columns. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -7973,10 +6429,6 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: gap between columns, in vp.
     pub const NODE_GRID_COLUMN_GAP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1013002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the gap between rows. This attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
@@ -7989,20 +6441,12 @@ impl ArkUI_NodeAttributeType {
     ///
     /// .value[0].f32: gap between lines, in vp.
     pub const NODE_GRID_ROW_GAP: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1013003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Defines the grid adapter. The attribute can be set, reset, and obtained as required through APIs.
     ///
     /// Format of the [`ArkUI_AttributeItem`] parameter for setting the attribute:
     ///
     /// .object: [`ArkUI_NodeAdapter`] object as the adapter.
     pub const NODE_GRID_NODE_ADAPTER: ArkUI_NodeAttributeType = ArkUI_NodeAttributeType(1013004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAttributeType {
     /// Sets the number of cached items in the grid adapter.
     /// This attribute can be set, reset, and obtained as required through APIs.
     ///
@@ -8051,10 +6495,6 @@ impl ArkUI_NodeEventType {
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
     /// [`ArkUI_UIInputEvent`].
     pub const NODE_TOUCH_EVENT: ArkUI_NodeEventType = ArkUI_NodeEventType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the mount event.
     ///
     /// This event is triggered when the component is mounted and displayed.
@@ -8064,10 +6504,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] does not contain parameters.
     pub const NODE_EVENT_ON_APPEAR: ArkUI_NodeEventType = ArkUI_NodeEventType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the unmount event.
     ///
     /// This event is triggered when the component is unmounted and hidden.
@@ -8077,10 +6513,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] does not contain parameters.
     pub const NODE_EVENT_ON_DISAPPEAR: ArkUI_NodeEventType = ArkUI_NodeEventType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the area change event.
     ///
     /// This event is triggered when the component's size, position, or any other attribute that may
@@ -8125,10 +6557,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponentEvent.data[11].f32</b>: new Y coordinate of the target element's upper left corner relative
     /// to the page's, in vp. The value type is number.
     pub const NODE_EVENT_ON_AREA_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the focus event.
     ///
     /// This event is triggered when the component obtains the focus.
@@ -8138,10 +6566,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] does not contain parameters.
     pub const NODE_ON_FOCUS: ArkUI_NodeEventType = ArkUI_NodeEventType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the blur event.
     ///
     /// This event is triggered when the component loses the focus.
@@ -8151,10 +6575,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] does not contain parameters.
     pub const NODE_ON_BLUR: ArkUI_NodeEventType = ArkUI_NodeEventType(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the click event.
     ///
     /// This event is triggered when the component is clicked.
@@ -8188,10 +6608,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponentEvent.data[7].f32</b>: Y coordinate of the click relative to the upper left corner of the
     /// application screen, in vp.
     pub const NODE_ON_CLICK: ArkUI_NodeEventType = ArkUI_NodeEventType(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines event interception.
     ///
     /// This event is triggered when the component is touched.
@@ -8199,10 +6615,6 @@ impl ArkUI_NodeEventType {
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
     /// [`ArkUI_UIInputEvent`].
     pub const NODE_ON_TOUCH_INTERCEPT: ArkUI_NodeEventType = ArkUI_NodeEventType(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the visible area change event.
     ///
     /// This event is triggered when the ratio of the component's visible area to its total area is greater than or less
@@ -8221,10 +6633,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponentEvent.data[1].f32</b>: ratio of the component's visible area to its total area when this
     /// callback is invoked.
     pub const NODE_EVENT_ON_VISIBLE_AREA_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the mouse pointer is moved over or away from the component.
     ///
     ///
@@ -8238,10 +6646,6 @@ impl ArkUI_NodeEventType {
     /// The value <b>1</b> indicates that the mouse pointer is hovered over the component, and <b>0</b> indicates that
     /// the mouse pointer is moved away from the component.
     pub const NODE_ON_HOVER: ArkUI_NodeEventType = ArkUI_NodeEventType(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the click event.
     ///
     /// This event is triggered when the component is clicked by a mouse device button or when the mouse pointer moves
@@ -8250,10 +6654,6 @@ impl ArkUI_NodeEventType {
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
     /// [`ArkUI_UIInputEvent`].
     pub const NODE_ON_MOUSE: ArkUI_NodeEventType = ArkUI_NodeEventType(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the attach event.
     ///
     /// This event is triggered when the component is attached.
@@ -8263,10 +6663,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] does not contain parameters.
     pub const NODE_EVENT_ON_ATTACH: ArkUI_NodeEventType = ArkUI_NodeEventType(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the detach event.
     ///
     /// This event is triggered when the component is detached.
@@ -8276,10 +6672,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] does not contain parameters.
     pub const NODE_EVENT_ON_DETACH: ArkUI_NodeEventType = ArkUI_NodeEventType(12);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the accessibility action event.
     ///
     /// This event is triggered when The accessibility operation type has been set and
@@ -8293,10 +6685,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponentEvent.data[0].u32</b>: accessibility action type，the union type is
     /// [`ArkUI_AccessibilityActionType`]
     pub const NODE_ON_ACCESSIBILITY_ACTIONS: ArkUI_NodeEventType = ArkUI_NodeEventType(13);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Notifies the listener of the interaction state prior to a drop and drop operation.
     ///
     /// This event is triggered when a drag operation is about to start on a draggable item.
@@ -8308,10 +6696,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0].i32</b>: corresponds to [`ArkUI_PreDragStatus`].
     pub const NODE_ON_PRE_DRAG: ArkUI_NodeEventType = ArkUI_NodeEventType(14);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Called when the user starts to drag an ite
     ///
     /// A drag operation is recognized only when the dragged item is moved far enough.
@@ -8319,10 +6703,6 @@ impl ArkUI_NodeEventType {
     /// When the event callback occurs, the [`ArkUI_DragEvent`] object can be obtained from the
     /// [`ArkUI_NodeEvent`] object.
     pub const NODE_ON_DRAG_START: ArkUI_NodeEventType = ArkUI_NodeEventType(15);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Called when a dragged item enters the boundaries of the current component.
     ///
     /// The current component refers to the component that listens for this event.
@@ -8330,10 +6710,6 @@ impl ArkUI_NodeEventType {
     /// When the event callback occurs, the [`ArkUI_DragEvent`] object can be obtained from the
     /// [`ArkUI_NodeEvent`] object.
     pub const NODE_ON_DRAG_ENTER: ArkUI_NodeEventType = ArkUI_NodeEventType(16);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Called when a dragged item moves in the current component.
     ///
     /// The current component refers to the component that listens for this event.
@@ -8341,10 +6717,6 @@ impl ArkUI_NodeEventType {
     /// When the event callback occurs, the [`ArkUI_DragEvent`] object can be obtained from the
     /// [`ArkUI_NodeEvent`] object.
     pub const NODE_ON_DRAG_MOVE: ArkUI_NodeEventType = ArkUI_NodeEventType(17);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Called when a dragged item leaves the boundaries of the current component.
     ///
     /// The current component refers to the component that listens for this event.
@@ -8352,10 +6724,6 @@ impl ArkUI_NodeEventType {
     /// When the event callback occurs, the [`ArkUI_DragEvent`] object can be obtained from the
     /// [`ArkUI_NodeEvent`] object.
     pub const NODE_ON_DRAG_LEAVE: ArkUI_NodeEventType = ArkUI_NodeEventType(18);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Called when a dragged item is dropped on the current component.
     /// The component can obtain the drag data for processing through the callback.
     ///
@@ -8364,10 +6732,6 @@ impl ArkUI_NodeEventType {
     /// When the event callback occurs, the [`ArkUI_DragEvent`] object can be obtained from the
     /// [`ArkUI_NodeEvent`] object.
     pub const NODE_ON_DROP: ArkUI_NodeEventType = ArkUI_NodeEventType(19);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Called when a drag operation ends.
     /// The drag source can obtain the drag result by registering this callback.
     ///
@@ -8375,10 +6739,6 @@ impl ArkUI_NodeEventType {
     /// When the event callback occurs, the [`ArkUI_DragEvent`] object can be obtained from the
     /// [`ArkUI_NodeEvent`] object.
     pub const NODE_ON_DRAG_END: ArkUI_NodeEventType = ArkUI_NodeEventType(20);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when a key event occurs.
     ///
     /// The callback can be triggered during interactions with a focused window using an external keyboard or other input
@@ -8393,10 +6753,6 @@ impl ArkUI_NodeEventType {
     #[cfg(feature = "api-14")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
     pub const NODE_ON_KEY_EVENT: ArkUI_NodeEventType = ArkUI_NodeEventType(21);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered before the input method responds to the key action.
     ///
     /// If the return value of this callback is <b>true</b>, it is considered that the key event has been consumed, and
@@ -8414,10 +6770,6 @@ impl ArkUI_NodeEventType {
     #[cfg(feature = "api-14")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
     pub const NODE_ON_KEY_PRE_IME: ArkUI_NodeEventType = ArkUI_NodeEventType(22);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Triggers onDetectResultUpdate callback
     /// when the text is set to TextDataDetectorConfig and recognized successfully.
     ///
@@ -8430,10 +6782,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_StringAsyncEvent.pStr</b>：Indicates the result of text recognition, in Json format.
     pub const NODE_TEXT_ON_DETECT_RESULT_UPDATE: ArkUI_NodeEventType = ArkUI_NodeEventType(1000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the image loading success event.
     ///
     /// This event is triggered when an image is successfully loaded or decoded.
@@ -8464,10 +6812,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[8].f32</b>: actual rendered height of the image, in px.
     pub const NODE_IMAGE_ON_COMPLETE: ArkUI_NodeEventType = ArkUI_NodeEventType(4000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the image loading failure event.
     ///
     /// This event is triggered when an error occurs during image loading.
@@ -8483,10 +6827,6 @@ impl ArkUI_NodeEventType {
     ///
     /// 103101: The image format is not supported.
     pub const NODE_IMAGE_ON_ERROR: ArkUI_NodeEventType = ArkUI_NodeEventType(4001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the SVG animation playback completion event.
     ///
     /// This event is triggered when the animation playback in the loaded SVG image is complete.
@@ -8496,10 +6836,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] does not contain parameters.
     pub const NODE_IMAGE_ON_SVG_PLAY_FINISH: ArkUI_NodeEventType = ArkUI_NodeEventType(4002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines image download process event.
     ///
     /// This event is triggered when downloading webpage images from page components.
@@ -8513,10 +6849,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[1].u32</b>: the total number of bytes to download.
     pub const NODE_IMAGE_ON_DOWNLOAD_PROGRESS: ArkUI_NodeEventType = ArkUI_NodeEventType(4003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the toggle status changes.
     ///
     ///
@@ -8528,10 +6860,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0].i32</b>: toggle status. <b>1</b>: on; <b>0</b>: off.
     pub const NODE_TOGGLE_ON_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(5000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the text input content changes.
     ///
     ///
@@ -8543,10 +6871,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_StringAsyncEvent.pStr</b>: text input.
     pub const NODE_TEXT_INPUT_ON_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(7000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the Enter key of the text input method is pressed.
     ///
     ///
@@ -8558,10 +6882,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0].i32</b>: Enter key type of the input method.
     pub const NODE_TEXT_INPUT_ON_SUBMIT: ArkUI_NodeEventType = ArkUI_NodeEventType(7001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the cut button on the pasteboard, which displays when the text box
     /// is long pressed, is clicked.
     ///
@@ -8574,10 +6894,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_StringAsyncEvent.pStr</b>: text that is cut.
     pub const NODE_TEXT_INPUT_ON_CUT: ArkUI_NodeEventType = ArkUI_NodeEventType(7002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the paste button on the pasteboard, which displays when the text box
     /// is long pressed, is clicked.
     ///
@@ -8590,10 +6906,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_StringAsyncEvent.pStr</b>: text that is pasted
     pub const NODE_TEXT_INPUT_ON_PASTE: ArkUI_NodeEventType = ArkUI_NodeEventType(7003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the text selection position changes.
     ///
     ///
@@ -8608,10 +6920,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponentEvent.data[1].i32</b>: end position of the text selection area.
     pub const NODE_TEXT_INPUT_ON_TEXT_SELECTION_CHANGE: ArkUI_NodeEventType =
         ArkUI_NodeEventType(7004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the input status changes.
     ///
     ///
@@ -8623,10 +6931,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0].i32</b>: <b>true</b> indicates that text input is in progress.
     pub const NODE_TEXT_INPUT_ON_EDIT_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(7005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// textInput This event is triggered when the input content changes.
     ///
     /// Conditions for triggering this event: When the input content changes.
@@ -8641,10 +6945,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponentEvent.data[1].f32</b>: Indicates the height of the text.
     pub const NODE_TEXT_INPUT_ON_CONTENT_SIZE_CHANGE: ArkUI_NodeEventType =
         ArkUI_NodeEventType(7006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when matching with the regular expression specified by
     /// <b>NODE_TEXT_INPUT_INPUT_FILTER</b> fails.
     ///
@@ -8658,10 +6958,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_StringAsyncEvent.pStr</b>: content that is filtered out when regular expression matching fails.
     pub const NODE_TEXT_INPUT_ON_INPUT_FILTER_ERROR: ArkUI_NodeEventType =
         ArkUI_NodeEventType(7007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// This callback is triggered when the text content is scrolled.
     ///
     ///
@@ -8677,10 +6973,6 @@ impl ArkUI_NodeEventType {
     ///
     /// the text in the content area.
     pub const NODE_TEXT_INPUT_ON_CONTENT_SCROLL: ArkUI_NodeEventType = ArkUI_NodeEventType(7008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when text is about to be entered.
     ///
     /// The event parameter is [`ArkUI_NodeEvent`].
@@ -8696,10 +6988,6 @@ impl ArkUI_NodeEventType {
     /// * Returns <b>true</b> if the text is entered; returns <b>false</b> otherwise.
     /// You can set the return value using <b>OH_ArkUI_NodeEvent_SetReturnNumberValue</b>.
     pub const NODE_TEXT_INPUT_ON_WILL_INSERT: ArkUI_NodeEventType = ArkUI_NodeEventType(7009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when text is entered.
     ///
     /// The event parameter is [`ArkUI_NodeEvent`].
@@ -8710,10 +6998,6 @@ impl ArkUI_NodeEventType {
     /// buffer: string value of the text, with the index of <b>0</b>; obtained using
     /// <b>OH_ArkUI_NodeEvent_GetStringValue</b>.
     pub const NODE_TEXT_INPUT_ON_DID_INSERT: ArkUI_NodeEventType = ArkUI_NodeEventType(7010);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when text is about to be deleted.
     ///
     /// The event parameter is [`ArkUI_NodeEvent`].
@@ -8734,10 +7018,6 @@ impl ArkUI_NodeEventType {
     ///
     /// You can set the return value using <b>OH_ArkUI_NodeEvent_SetReturnNumberValue</b>.
     pub const NODE_TEXT_INPUT_ON_WILL_DELETE: ArkUI_NodeEventType = ArkUI_NodeEventType(7011);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when text is deleted.
     ///
     /// The event parameter is [`ArkUI_NodeEvent`].
@@ -8752,10 +7032,6 @@ impl ArkUI_NodeEventType {
     /// buffer: string value of the text, with the index of <b>0</b>; obtained using
     /// <b>OH_ArkUI_NodeEvent_GetStringValue</b>.
     pub const NODE_TEXT_INPUT_ON_DID_DELETE: ArkUI_NodeEventType = ArkUI_NodeEventType(7012);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the input in the text box changes.
     ///
     ///
@@ -8767,10 +7043,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_StringAsyncEvent.pStr</b>: text entered.
     pub const NODE_TEXT_AREA_ON_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(8000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the paste button on the pasteboard, which displays when the text box is
     /// long pressed, is clicked.
     ///
@@ -8783,10 +7055,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_StringAsyncEvent.pStr</b>: text that is pasted
     pub const NODE_TEXT_AREA_ON_PASTE: ArkUI_NodeEventType = ArkUI_NodeEventType(8001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the text selection position changes.
     ///
     ///
@@ -8801,10 +7069,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponentEvent.data[1].i32</b>: end position of the text selection area.
     pub const NODE_TEXT_AREA_ON_TEXT_SELECTION_CHANGE: ArkUI_NodeEventType =
         ArkUI_NodeEventType(8002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when matching with the regular expression specified by
     /// <b>NODE_TEXT_AREA_INPUT_FILTER</b> fails.
     ///
@@ -8817,10 +7081,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_StringAsyncEvent.pStr</b>: content that is filtered out when regular expression matching fails.
     pub const NODE_TEXT_AREA_ON_INPUT_FILTER_ERROR: ArkUI_NodeEventType = ArkUI_NodeEventType(8003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// This callback is triggered when the text content is scrolled.
     ///
     ///
@@ -8836,10 +7096,6 @@ impl ArkUI_NodeEventType {
     ///
     /// the text in the content area.
     pub const NODE_TEXT_AREA_ON_CONTENT_SCROLL: ArkUI_NodeEventType = ArkUI_NodeEventType(8004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the input status changes.
     ///
     ///
@@ -8852,10 +7108,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0].i32</b>: <b>true</b> indicates that text input is in progress.
     pub const NODE_TEXT_AREA_ON_EDIT_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(8005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the Enter key on the keyboard is pressed for the multi-line text box.
     ///
     /// This event is not triggered when <b>keyType</b> is <b>ARKUI_ENTER_KEY_TYPE_NEW_LINE</b>.
@@ -8868,10 +7120,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0].i32</b>: type of the Enter key.
     pub const NODE_TEXT_AREA_ON_SUBMIT: ArkUI_NodeEventType = ArkUI_NodeEventType(8006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// textArea This event is triggered when the input content changes.
     ///
     /// Conditions for triggering this event: When the input content changes.
@@ -8887,10 +7135,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponentEvent.data[1].f32</b>: Indicates the height of the text.
     pub const NODE_TEXT_AREA_ON_CONTENT_SIZE_CHANGE: ArkUI_NodeEventType =
         ArkUI_NodeEventType(8007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when text is about to be entered.
     ///
     /// The event parameter is [`ArkUI_NodeEvent`].
@@ -8906,10 +7150,6 @@ impl ArkUI_NodeEventType {
     /// * Returns <b>true</b> if the text is entered; returns <b>false</b> otherwise.
     /// You can set the return value using <b>OH_ArkUI_NodeEvent_SetReturnNumberValue</b>.
     pub const NODE_TEXT_AREA_ON_WILL_INSERT: ArkUI_NodeEventType = ArkUI_NodeEventType(8008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when text is entered.
     ///
     /// The event parameter is [`ArkUI_NodeEvent`].
@@ -8920,10 +7160,6 @@ impl ArkUI_NodeEventType {
     /// buffer: string value of the text, with the index of <b>0</b>; obtained using
     /// <b>OH_ArkUI_NodeEvent_GetStringValue</b>.
     pub const NODE_TEXT_AREA_ON_DID_INSERT: ArkUI_NodeEventType = ArkUI_NodeEventType(8009);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when text is about to be deleted.
     ///
     /// The event parameter is [`ArkUI_NodeEvent`].
@@ -8944,10 +7180,6 @@ impl ArkUI_NodeEventType {
     ///
     /// You can set the return value using <b>OH_ArkUI_NodeEvent_SetReturnNumberValue</b>.
     pub const NODE_TEXT_AREA_ON_WILL_DELETE: ArkUI_NodeEventType = ArkUI_NodeEventType(8010);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when text is deleted.
     ///
     /// The event parameter is [`ArkUI_NodeEvent`].
@@ -8962,10 +7194,6 @@ impl ArkUI_NodeEventType {
     /// buffer: string value of the text, with the index of <b>0</b>; obtained using
     /// <b>OH_ArkUI_NodeEvent_GetStringValue</b>.
     pub const NODE_TEXT_AREA_ON_DID_DELETE: ArkUI_NodeEventType = ArkUI_NodeEventType(8011);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the selected status of the <b>ARKUI_NODE_CHECKBOX</b> component changes.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -8973,10 +7201,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0].i32</b><b>1</b>: selected; <b>0</b>: not selected.
     pub const NODE_CHECKBOX_EVENT_ON_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(11000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when a date is selected in the <b>ARKUI_NODE_DATE_PICKER</b> component.
     ///
     ///
@@ -8993,10 +7217,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponentEvent.data[2].i32</b>: day of the selected date.
     pub const NODE_DATE_PICKER_EVENT_ON_DATE_CHANGE: ArkUI_NodeEventType =
         ArkUI_NodeEventType(13000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when a time is selected in the <b>ARKUI_NODE_TIME_PICKER</b> component.
     ///
     ///
@@ -9010,10 +7230,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[1].i32</b>: minute of the selected time. Value range: [0-59].
     pub const NODE_TIME_PICKER_EVENT_ON_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(14000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when an item is selected in the <b>ARKUI_NODE_TEXT_PICKER</b> component.
     ///
     ///
@@ -9025,10 +7241,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0...11].i32</b>: value of the selected item.
     pub const NODE_TEXT_PICKER_EVENT_ON_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(15000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when an item is selected and scrolling has stopped in the
     /// <b>ARKUI_NODE_TEXT_PICKER</b> component.
     ///
@@ -9046,10 +7258,6 @@ impl ArkUI_NodeEventType {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
     pub const NODE_TEXT_PICKER_EVENT_ON_SCROLL_STOP: ArkUI_NodeEventType =
         ArkUI_NodeEventType(15001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when a date is selected in the <b>NODE_CALENDAR_PICKER</b>.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9062,10 +7270,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponent.data[2].u32</b>: day of the selected date.
     pub const NODE_CALENDAR_PICKER_EVENT_ON_CHANGE: ArkUI_NodeEventType =
         ArkUI_NodeEventType(16000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the <b>ARKUI_NODE_SLIDER</b> component is dragged or clicked.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9077,10 +7281,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[1].i32</b>: state triggered by the event.
     pub const NODE_SLIDER_EVENT_ON_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(17000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event callback function triggered when an object is dragged or clicked by ARKUI_NODE_RADIO.
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
     ///
@@ -9090,10 +7290,6 @@ impl ArkUI_NodeEventType {
     ///
     /// ArkUI_NodeComponentEvent.data[0].i32: option button status.
     pub const NODE_RADIO_EVENT_ON_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(18000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event callback function triggered when the animation starts to play.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9102,10 +7298,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] contains no parameter:
     pub const NODE_IMAGE_ANIMATOR_EVENT_ON_START: ArkUI_NodeEventType = ArkUI_NodeEventType(19000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event callback function triggered when the animation playback is paused.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9114,10 +7306,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] contains no parameter:
     pub const NODE_IMAGE_ANIMATOR_EVENT_ON_PAUSE: ArkUI_NodeEventType = ArkUI_NodeEventType(19001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event callback function triggered when the animation playback is repeated.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9126,10 +7314,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] contains no parameter:
     pub const NODE_IMAGE_ANIMATOR_EVENT_ON_REPEAT: ArkUI_NodeEventType = ArkUI_NodeEventType(19002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event callback function when the animation playback returns to the initial state.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9138,10 +7322,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] contains no parameter:
     pub const NODE_IMAGE_ANIMATOR_EVENT_ON_CANCEL: ArkUI_NodeEventType = ArkUI_NodeEventType(19003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event callback function triggered when the animation playback is complete or stopped.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9150,10 +7330,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] contains no parameter:
     pub const NODE_IMAGE_ANIMATOR_EVENT_ON_FINISH: ArkUI_NodeEventType = ArkUI_NodeEventType(19004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the index of the currently displayed element of this
     /// <b>ARKUI_NODE_SWIPER</b> instance changes.
     ///
@@ -9164,10 +7340,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0].i32</b>: index of the currently displayed element.
     pub const NODE_SWIPER_EVENT_ON_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(1001000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the switching animation of this <b>ARKUI_NODE_SWIPER</b> instance starts.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9188,10 +7360,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponentEvent.data[4].f32</b>: hands-off velocity.
     pub const NODE_SWIPER_EVENT_ON_ANIMATION_START: ArkUI_NodeEventType =
         ArkUI_NodeEventType(1001001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the switching animation of this <b>ARKUI_NODE_SWIPER</b> instance ends.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9205,10 +7373,6 @@ impl ArkUI_NodeEventType {
     /// start position of the swiper along the main axis.
     pub const NODE_SWIPER_EVENT_ON_ANIMATION_END: ArkUI_NodeEventType =
         ArkUI_NodeEventType(1001002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered on a frame-by-frame basis when the page is turned by a swipe in this
     /// <b>ARKUI_NODE_SWIPER</b> instance.
     ///
@@ -9223,10 +7387,6 @@ impl ArkUI_NodeEventType {
     /// start position of the swiper along the main axis.
     pub const NODE_SWIPER_EVENT_ON_GESTURE_SWIPE: ArkUI_NodeEventType =
         ArkUI_NodeEventType(1001003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Define the <b>ARKUI_NODE_SWIPER</b> to listen for Swiper page slide events.
     /// Instruction:
     ///
@@ -9270,10 +7430,6 @@ impl ArkUI_NodeEventType {
     /// <b>ArkUI_NodeComponentEvent.data[3].f32</b> : The length of the page in the axis direction.
     pub const NODE_SWIPER_EVENT_ON_CONTENT_DID_SCROLL: ArkUI_NodeEventType =
         ArkUI_NodeEventType(1001004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the <b>ARKUI_NODE_SCROLL</b> component scrolls.
     ///
     /// Notes for triggering the event:
@@ -9294,10 +7450,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[1].f32</b>: vertical scrolling offset.
     pub const NODE_SCROLL_EVENT_ON_SCROLL: ArkUI_NodeEventType = ArkUI_NodeEventType(1002000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when each frame scrolling starts in the <b>ARKUI_NODE_SCROLL</b> component.
     ///
     /// Notes for triggering the event:
@@ -9324,10 +7476,6 @@ impl ArkUI_NodeEventType {
     /// needs to scroll based on the real-world situation and return the result in this parameter.
     pub const NODE_SCROLL_EVENT_ON_SCROLL_FRAME_BEGIN: ArkUI_NodeEventType =
         ArkUI_NodeEventType(1002001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Define the enumeration value of the pre sliding trigger event for the scrolling container component.
     ///
     /// The conditions that trigger this event:
@@ -9363,10 +7511,6 @@ impl ArkUI_NodeEventType {
     ///
     /// * Does not return or returns a number that sets the actual scroll distance of the scroll component.
     pub const NODE_SCROLL_EVENT_ON_WILL_SCROLL: ArkUI_NodeEventType = ArkUI_NodeEventType(1002002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Define the event enumeration value triggered when sliding a scrolling container component.
     ///
     /// The conditions that trigger this event:
@@ -9393,10 +7537,6 @@ impl ArkUI_NodeEventType {
     ///
     /// parameter type is [`ArkUI_ScrollState`].
     pub const NODE_SCROLL_EVENT_ON_DID_SCROLL: ArkUI_NodeEventType = ArkUI_NodeEventType(1002003);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when scrolling starts in the <b>ARKUI_NODE_SCROLL</b> component.
     ///
     /// Notes for triggering the event:
@@ -9411,10 +7551,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] does not contain parameters.
     pub const NODE_SCROLL_EVENT_ON_SCROLL_START: ArkUI_NodeEventType = ArkUI_NodeEventType(1002004);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when scrolling of the <b>ARKUI_NODE_SCROLL</b> component stops.
     ///
     /// Notes for triggering the event:
@@ -9429,10 +7565,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] does not contain parameters.
     pub const NODE_SCROLL_EVENT_ON_SCROLL_STOP: ArkUI_NodeEventType = ArkUI_NodeEventType(1002005);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when scrolling of the <b>ARKUI_NODE_SCROLL</b> component reaches
     /// one of the edges.
     ///
@@ -9452,10 +7584,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0].i32</b>: edge (top, bottom, left, or right) that the scrolling reaches.
     pub const NODE_SCROLL_EVENT_ON_SCROLL_EDGE: ArkUI_NodeEventType = ArkUI_NodeEventType(1002006);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Define that a callback is triggered when the scrolling container component reaches the start position.
     /// Condition for triggering the event:
     ///
@@ -9466,10 +7594,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] contains no parameters.
     pub const NODE_SCROLL_EVENT_ON_REACH_START: ArkUI_NodeEventType = ArkUI_NodeEventType(1002007);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Define that a callback is triggered when the scrolling container component ends.
     ///
     /// Condition for triggering the event:
@@ -9481,10 +7605,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] contains no parameters.
     pub const NODE_SCROLL_EVENT_ON_REACH_END: ArkUI_NodeEventType = ArkUI_NodeEventType(1002008);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the enumerated values of the event triggered,
     ///
     /// when a subcomponent of ARKUI_NODE_LIST is moved into or out of the list display area.
@@ -9512,10 +7632,6 @@ impl ArkUI_NodeEventType {
     ///
     /// the subcomponent in the middle of the area.
     pub const NODE_LIST_ON_SCROLL_INDEX: ArkUI_NodeEventType = ArkUI_NodeEventType(1003000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the enumerated values of the event triggered
     /// before the sliding of the ARKUI_NODE_LIST component.
     ///
@@ -9554,10 +7670,6 @@ impl ArkUI_NodeEventType {
     ///
     /// * Does not return or returns a number that sets the actual scroll distance of the scroll component.
     pub const NODE_LIST_ON_WILL_SCROLL: ArkUI_NodeEventType = ArkUI_NodeEventType(1003001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Define the enumerated values of the event triggered when the ARKUI_NODE_LIST component is flicked.
     /// Condition for triggering the event:
     ///
@@ -9583,10 +7695,6 @@ impl ArkUI_NodeEventType {
     ///
     /// ArkUI_NodeComponentEvent.data[1].i32: Current sliding state.
     pub const NODE_LIST_ON_DID_SCROLL: ArkUI_NodeEventType = ArkUI_NodeEventType(1003002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the refresh state of the <b>ARKUI_NODE_REFRESH</b> object changes.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9596,10 +7704,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0].i32</b>: refresh state.
     pub const NODE_REFRESH_STATE_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(1009000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the <b>ARKUI_NODE_REFRESH</b> object enters the refresh state.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9607,10 +7711,6 @@ impl ArkUI_NodeEventType {
     ///
     /// [`ArkUI_NodeComponentEvent`] does not contain parameters:
     pub const NODE_REFRESH_ON_REFRESH: ArkUI_NodeEventType = ArkUI_NodeEventType(1009001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event that is triggered when the <b>ARKUI_NODE_REFRESH</b> drop-down distance changes.
     ///
     /// When the event callback occurs, the union type in the [`ArkUI_NodeEvent`] object is
@@ -9620,10 +7720,6 @@ impl ArkUI_NodeEventType {
     ///
     /// <b>ArkUI_NodeComponentEvent.data[0].f32</b>: Pull-down distance.
     pub const NODE_REFRESH_ON_OFFSET_CHANGE: ArkUI_NodeEventType = ArkUI_NodeEventType(1009002);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the event triggered when the <b>ARKUI_NODE_SCROLL</b> component is about to scroll.
     ///
     /// Notes for triggering the event:
@@ -9659,10 +7755,6 @@ impl ArkUI_NodeEventType {
     ///
     /// * Does not return or returns a number that sets the actual scroll distance of the scroll component.
     pub const NODE_ON_WILL_SCROLL: ArkUI_NodeEventType = ArkUI_NodeEventType(1010000);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Define the enumerated values of the event triggered when the ARKUI_NODE_WATER_FLOW component slides.
     /// Condition for triggering the event:
     ///
@@ -9685,10 +7777,6 @@ impl ArkUI_NodeEventType {
     ///
     /// ArkUI_NodeComponentEvent.data[1].i32: Current sliding state.
     pub const NODE_WATER_FLOW_ON_DID_SCROLL: ArkUI_NodeEventType = ArkUI_NodeEventType(1010001);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeEventType {
     /// Defines the enumerated values of the event triggered,
     /// when the subcomponent of the start position or end position displayed in the current waterfall changes.
     /// Condition for triggering the event:
@@ -9732,16 +7820,8 @@ impl ArkUI_NodeDirtyFlag {
     ///
     /// When this type of flag is specified, re-layout is triggered by default.
     pub const NODE_NEED_MEASURE: ArkUI_NodeDirtyFlag = ArkUI_NodeDirtyFlag(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeDirtyFlag {
     /// Re-layout.
     pub const NODE_NEED_LAYOUT: ArkUI_NodeDirtyFlag = ArkUI_NodeDirtyFlag(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeDirtyFlag {
     /// Re-rendering.
     pub const NODE_NEED_RENDER: ArkUI_NodeDirtyFlag = ArkUI_NodeDirtyFlag(3);
 }
@@ -9760,31 +7840,15 @@ impl ArkUI_NodeCustomEventType {
     /// Measure type.
     pub const ARKUI_NODE_CUSTOM_EVENT_ON_MEASURE: ArkUI_NodeCustomEventType =
         ArkUI_NodeCustomEventType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeCustomEventType {
     /// Layout type.
     pub const ARKUI_NODE_CUSTOM_EVENT_ON_LAYOUT: ArkUI_NodeCustomEventType =
         ArkUI_NodeCustomEventType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeCustomEventType {
     /// Draw type.
     pub const ARKUI_NODE_CUSTOM_EVENT_ON_DRAW: ArkUI_NodeCustomEventType =
         ArkUI_NodeCustomEventType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeCustomEventType {
     /// Foreground type.
     pub const ARKUI_NODE_CUSTOM_EVENT_ON_FOREGROUND_DRAW: ArkUI_NodeCustomEventType =
         ArkUI_NodeCustomEventType(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeCustomEventType {
     /// Overlay type.
     pub const ARKUI_NODE_CUSTOM_EVENT_ON_OVERLAY_DRAW: ArkUI_NodeCustomEventType =
         ArkUI_NodeCustomEventType(16);
@@ -9823,31 +7887,15 @@ impl ArkUI_NodeAdapterEventType {
     /// This event occurs when the component is attached to the adapter.
     pub const NODE_ADAPTER_EVENT_WILL_ATTACH_TO_NODE: ArkUI_NodeAdapterEventType =
         ArkUI_NodeAdapterEventType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAdapterEventType {
     /// This event occurs when the component is detached from the adapter.
     pub const NODE_ADAPTER_EVENT_WILL_DETACH_FROM_NODE: ArkUI_NodeAdapterEventType =
         ArkUI_NodeAdapterEventType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAdapterEventType {
     /// This event occurs when the adapter obtains the unique ID of the new element to add.
     pub const NODE_ADAPTER_EVENT_ON_GET_NODE_ID: ArkUI_NodeAdapterEventType =
         ArkUI_NodeAdapterEventType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAdapterEventType {
     /// This event occurs when the adapter obtains the content of the new element to add.
     pub const NODE_ADAPTER_EVENT_ON_ADD_NODE_TO_ADAPTER: ArkUI_NodeAdapterEventType =
         ArkUI_NodeAdapterEventType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeAdapterEventType {
     /// This event occurs when the adapter removes an element.
     pub const NODE_ADAPTER_EVENT_ON_REMOVE_NODE_FROM_ADAPTER: ArkUI_NodeAdapterEventType =
         ArkUI_NodeAdapterEventType(5);
@@ -10567,10 +8615,6 @@ impl ArkUI_NodeContentEventType {
     /// Defines the attach event.
     pub const NODE_CONTENT_EVENT_ON_ATTACH_TO_WINDOW: ArkUI_NodeContentEventType =
         ArkUI_NodeContentEventType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NodeContentEventType {
     /// Defines the detach event.
     pub const NODE_CONTENT_EVENT_ON_DETACH_FROM_WINDOW: ArkUI_NodeContentEventType =
         ArkUI_NodeContentEventType(1);

--- a/components/arkui/src/native_type/native_type_ffi.rs
+++ b/components/arkui/src/native_type/native_type_ffi.rs
@@ -166,52 +166,20 @@ pub union ArkUI_NumberValue {
 impl ArkUI_Alignment {
     /// Top start.
     pub const ARKUI_ALIGNMENT_TOP_START: ArkUI_Alignment = ArkUI_Alignment(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Alignment {
     /// Top center.
     pub const ARKUI_ALIGNMENT_TOP: ArkUI_Alignment = ArkUI_Alignment(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Alignment {
     /// Top end.
     pub const ARKUI_ALIGNMENT_TOP_END: ArkUI_Alignment = ArkUI_Alignment(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Alignment {
     /// Vertically centered start.
     pub const ARKUI_ALIGNMENT_START: ArkUI_Alignment = ArkUI_Alignment(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Alignment {
     /// Horizontally and vertically centered.
     pub const ARKUI_ALIGNMENT_CENTER: ArkUI_Alignment = ArkUI_Alignment(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Alignment {
     /// Vertically centered end.
     pub const ARKUI_ALIGNMENT_END: ArkUI_Alignment = ArkUI_Alignment(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Alignment {
     /// Bottom start.
     pub const ARKUI_ALIGNMENT_BOTTOM_START: ArkUI_Alignment = ArkUI_Alignment(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Alignment {
     /// Horizontally centered on the bottom.
     pub const ARKUI_ALIGNMENT_BOTTOM: ArkUI_Alignment = ArkUI_Alignment(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Alignment {
     /// Bottom end.
     pub const ARKUI_ALIGNMENT_BOTTOM_END: ArkUI_Alignment = ArkUI_Alignment(8);
 }
@@ -229,22 +197,10 @@ pub struct ArkUI_Alignment(pub ::core::ffi::c_uint);
 impl ArkUI_ImageRepeat {
     /// The image is not repeatedly drawn.
     pub const ARKUI_IMAGE_REPEAT_NONE: ArkUI_ImageRepeat = ArkUI_ImageRepeat(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageRepeat {
     /// The image is repeatedly drawn only along the x-axis.
     pub const ARKUI_IMAGE_REPEAT_X: ArkUI_ImageRepeat = ArkUI_ImageRepeat(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageRepeat {
     /// The image is repeatedly drawn only along the y-axis.
     pub const ARKUI_IMAGE_REPEAT_Y: ArkUI_ImageRepeat = ArkUI_ImageRepeat(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageRepeat {
     /// The image is repeatedly drawn along both axes.
     pub const ARKUI_IMAGE_REPEAT_XY: ArkUI_ImageRepeat = ArkUI_ImageRepeat(3);
 }
@@ -262,10 +218,6 @@ pub struct ArkUI_ImageRepeat(pub ::core::ffi::c_uint);
 impl ArkUI_FontStyle {
     /// Standard font style.
     pub const ARKUI_FONT_STYLE_NORMAL: ArkUI_FontStyle = ArkUI_FontStyle(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontStyle {
     /// Italic font style.
     pub const ARKUI_FONT_STYLE_ITALIC: ArkUI_FontStyle = ArkUI_FontStyle(1);
 }
@@ -283,88 +235,32 @@ pub struct ArkUI_FontStyle(pub ::core::ffi::c_uint);
 impl ArkUI_FontWeight {
     /// 100
     pub const ARKUI_FONT_WEIGHT_W100: ArkUI_FontWeight = ArkUI_FontWeight(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// 200
     pub const ARKUI_FONT_WEIGHT_W200: ArkUI_FontWeight = ArkUI_FontWeight(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// 300
     pub const ARKUI_FONT_WEIGHT_W300: ArkUI_FontWeight = ArkUI_FontWeight(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// 400
     pub const ARKUI_FONT_WEIGHT_W400: ArkUI_FontWeight = ArkUI_FontWeight(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// 500
     pub const ARKUI_FONT_WEIGHT_W500: ArkUI_FontWeight = ArkUI_FontWeight(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// 600
     pub const ARKUI_FONT_WEIGHT_W600: ArkUI_FontWeight = ArkUI_FontWeight(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// 700
     pub const ARKUI_FONT_WEIGHT_W700: ArkUI_FontWeight = ArkUI_FontWeight(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// 800
     pub const ARKUI_FONT_WEIGHT_W800: ArkUI_FontWeight = ArkUI_FontWeight(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// 900
     pub const ARKUI_FONT_WEIGHT_W900: ArkUI_FontWeight = ArkUI_FontWeight(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// The font weight is bold.
     pub const ARKUI_FONT_WEIGHT_BOLD: ArkUI_FontWeight = ArkUI_FontWeight(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// The font weight is normal.
     pub const ARKUI_FONT_WEIGHT_NORMAL: ArkUI_FontWeight = ArkUI_FontWeight(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// The font weight is bolder.
     pub const ARKUI_FONT_WEIGHT_BOLDER: ArkUI_FontWeight = ArkUI_FontWeight(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// The font weight is lighter.
     pub const ARKUI_FONT_WEIGHT_LIGHTER: ArkUI_FontWeight = ArkUI_FontWeight(12);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// The font weight is medium.
     pub const ARKUI_FONT_WEIGHT_MEDIUM: ArkUI_FontWeight = ArkUI_FontWeight(13);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FontWeight {
     /// The font weight is normal.
     pub const ARKUI_FONT_WEIGHT_REGULAR: ArkUI_FontWeight = ArkUI_FontWeight(14);
 }
@@ -382,22 +278,10 @@ pub struct ArkUI_FontWeight(pub ::core::ffi::c_uint);
 impl ArkUI_TextAlignment {
     /// Aligned with the start.
     pub const ARKUI_TEXT_ALIGNMENT_START: ArkUI_TextAlignment = ArkUI_TextAlignment(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextAlignment {
     /// Horizontally centered.
     pub const ARKUI_TEXT_ALIGNMENT_CENTER: ArkUI_TextAlignment = ArkUI_TextAlignment(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextAlignment {
     /// Aligned with the end.
     pub const ARKUI_TEXT_ALIGNMENT_END: ArkUI_TextAlignment = ArkUI_TextAlignment(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextAlignment {
     /// Aligned with both margins.
     pub const ARKUI_TEXT_ALIGNMENT_JUSTIFY: ArkUI_TextAlignment = ArkUI_TextAlignment(3);
 }
@@ -415,40 +299,16 @@ pub struct ArkUI_TextAlignment(pub ::core::ffi::c_uint);
 impl ArkUI_EnterKeyType {
     /// The Enter key is labeled "Go."
     pub const ARKUI_ENTER_KEY_TYPE_GO: ArkUI_EnterKeyType = ArkUI_EnterKeyType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_EnterKeyType {
     /// The Enter key is labeled "Search."
     pub const ARKUI_ENTER_KEY_TYPE_SEARCH: ArkUI_EnterKeyType = ArkUI_EnterKeyType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_EnterKeyType {
     /// The Enter key is labeled "Send."
     pub const ARKUI_ENTER_KEY_TYPE_SEND: ArkUI_EnterKeyType = ArkUI_EnterKeyType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_EnterKeyType {
     /// The Enter key is labeled "Next."
     pub const ARKUI_ENTER_KEY_TYPE_NEXT: ArkUI_EnterKeyType = ArkUI_EnterKeyType(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_EnterKeyType {
     /// The Enter key is labeled "Done."
     pub const ARKUI_ENTER_KEY_TYPE_DONE: ArkUI_EnterKeyType = ArkUI_EnterKeyType(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_EnterKeyType {
     /// The Enter key is labeled "Previous."
     pub const ARKUI_ENTER_KEY_TYPE_PREVIOUS: ArkUI_EnterKeyType = ArkUI_EnterKeyType(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_EnterKeyType {
     /// The Enter key is labeled "New Line."
     pub const ARKUI_ENTER_KEY_TYPE_NEW_LINE: ArkUI_EnterKeyType = ArkUI_EnterKeyType(8);
 }
@@ -466,59 +326,23 @@ pub struct ArkUI_EnterKeyType(pub ::core::ffi::c_uint);
 impl ArkUI_TextInputType {
     /// Normal input mode.
     pub const ARKUI_TEXTINPUT_TYPE_NORMAL: ArkUI_TextInputType = ArkUI_TextInputType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputType {
     /// Number input mode.
     pub const ARKUI_TEXTINPUT_TYPE_NUMBER: ArkUI_TextInputType = ArkUI_TextInputType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputType {
     /// Phone number input mode.
     pub const ARKUI_TEXTINPUT_TYPE_PHONE_NUMBER: ArkUI_TextInputType = ArkUI_TextInputType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputType {
     /// Email address input mode.
     pub const ARKUI_TEXTINPUT_TYPE_EMAIL: ArkUI_TextInputType = ArkUI_TextInputType(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputType {
     /// Password input mode.
     pub const ARKUI_TEXTINPUT_TYPE_PASSWORD: ArkUI_TextInputType = ArkUI_TextInputType(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputType {
     /// Numeric password input mode.
     pub const ARKUI_TEXTINPUT_TYPE_NUMBER_PASSWORD: ArkUI_TextInputType = ArkUI_TextInputType(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputType {
     /// Lock screen password input mode.
     pub const ARKUI_TEXTINPUT_TYPE_SCREEN_LOCK_PASSWORD: ArkUI_TextInputType =
         ArkUI_TextInputType(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputType {
     /// Username input mode.
     pub const ARKUI_TEXTINPUT_TYPE_USER_NAME: ArkUI_TextInputType = ArkUI_TextInputType(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputType {
     /// New password input mode.
     pub const ARKUI_TEXTINPUT_TYPE_NEW_PASSWORD: ArkUI_TextInputType = ArkUI_TextInputType(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputType {
     /// Number input mode with a decimal point.
     pub const ARKUI_TEXTINPUT_TYPE_NUMBER_DECIMAL: ArkUI_TextInputType = ArkUI_TextInputType(12);
 }
@@ -536,22 +360,10 @@ pub struct ArkUI_TextInputType(pub ::core::ffi::c_uint);
 impl ArkUI_TextAreaType {
     /// Normal input mode.
     pub const ARKUI_TEXTAREA_TYPE_NORMAL: ArkUI_TextAreaType = ArkUI_TextAreaType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextAreaType {
     /// Number input mode.
     pub const ARKUI_TEXTAREA_TYPE_NUMBER: ArkUI_TextAreaType = ArkUI_TextAreaType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextAreaType {
     /// Phone number input mode.
     pub const ARKUI_TEXTAREA_TYPE_PHONE_NUMBER: ArkUI_TextAreaType = ArkUI_TextAreaType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextAreaType {
     /// Email address input mode.
     pub const ARKUI_TEXTAREA_TYPE_EMAIL: ArkUI_TextAreaType = ArkUI_TextAreaType(5);
 }
@@ -570,17 +382,9 @@ impl ArkUI_CancelButtonStyle {
     /// The Cancel button is always displayed.
     pub const ARKUI_CANCELBUTTON_STYLE_CONSTANT: ArkUI_CancelButtonStyle =
         ArkUI_CancelButtonStyle(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_CancelButtonStyle {
     /// The Cancel button is always hidden.
     pub const ARKUI_CANCELBUTTON_STYLE_INVISIBLE: ArkUI_CancelButtonStyle =
         ArkUI_CancelButtonStyle(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_CancelButtonStyle {
     /// The Cancel button is displayed when there is text input.
     pub const ARKUI_CANCELBUTTON_STYLE_INPUT: ArkUI_CancelButtonStyle = ArkUI_CancelButtonStyle(2);
 }
@@ -598,10 +402,6 @@ pub struct ArkUI_CancelButtonStyle(pub ::core::ffi::c_uint);
 impl ArkUI_XComponentType {
     /// The custom content of EGL/OpenGL ES and media data is displayed individually on the screen.
     pub const ARKUI_XCOMPONENT_TYPE_SURFACE: ArkUI_XComponentType = ArkUI_XComponentType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_XComponentType {
     /// The custom content of EGL/OpenGL ES and media data is grouped and displayed together with content
     /// of the component.
     pub const ARKUI_XCOMPONENT_TYPE_TEXTURE: ArkUI_XComponentType = ArkUI_XComponentType(2);
@@ -620,28 +420,12 @@ pub struct ArkUI_XComponentType(pub ::core::ffi::c_uint);
 impl ArkUI_ProgressType {
     /// Linear style.
     pub const ARKUI_PROGRESS_TYPE_LINEAR: ArkUI_ProgressType = ArkUI_ProgressType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ProgressType {
     /// Indeterminate ring style.
     pub const ARKUI_PROGRESS_TYPE_RING: ArkUI_ProgressType = ArkUI_ProgressType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ProgressType {
     /// Eclipse style.
     pub const ARKUI_PROGRESS_TYPE_ECLIPSE: ArkUI_ProgressType = ArkUI_ProgressType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ProgressType {
     /// Determinate ring style.
     pub const ARKUI_PROGRESS_TYPE_SCALE_RING: ArkUI_ProgressType = ArkUI_ProgressType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ProgressType {
     /// Capsule style.
     pub const ARKUI_PROGRESS_TYPE_CAPSULE: ArkUI_ProgressType = ArkUI_ProgressType(4);
 }
@@ -660,24 +444,12 @@ impl ArkUI_TextDecorationType {
     /// No text decoration.
     pub const ARKUI_TEXT_DECORATION_TYPE_NONE: ArkUI_TextDecorationType =
         ArkUI_TextDecorationType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextDecorationType {
     /// Line under the text.
     pub const ARKUI_TEXT_DECORATION_TYPE_UNDERLINE: ArkUI_TextDecorationType =
         ArkUI_TextDecorationType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextDecorationType {
     /// Line over the text.
     pub const ARKUI_TEXT_DECORATION_TYPE_OVERLINE: ArkUI_TextDecorationType =
         ArkUI_TextDecorationType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextDecorationType {
     /// Line through the text.
     pub const ARKUI_TEXT_DECORATION_TYPE_LINE_THROUGH: ArkUI_TextDecorationType =
         ArkUI_TextDecorationType(3);
@@ -697,31 +469,15 @@ impl ArkUI_TextDecorationStyle {
     /// Single solid line.
     pub const ARKUI_TEXT_DECORATION_STYLE_SOLID: ArkUI_TextDecorationStyle =
         ArkUI_TextDecorationStyle(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextDecorationStyle {
     /// Double solid line.
     pub const ARKUI_TEXT_DECORATION_STYLE_DOUBLE: ArkUI_TextDecorationStyle =
         ArkUI_TextDecorationStyle(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextDecorationStyle {
     /// Dotted line.
     pub const ARKUI_TEXT_DECORATION_STYLE_DOTTED: ArkUI_TextDecorationStyle =
         ArkUI_TextDecorationStyle(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextDecorationStyle {
     /// Dashed line.
     pub const ARKUI_TEXT_DECORATION_STYLE_DASHED: ArkUI_TextDecorationStyle =
         ArkUI_TextDecorationStyle(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextDecorationStyle {
     /// Wavy line.
     pub const ARKUI_TEXT_DECORATION_STYLE_WAVY: ArkUI_TextDecorationStyle =
         ArkUI_TextDecorationStyle(4);
@@ -740,16 +496,8 @@ pub struct ArkUI_TextDecorationStyle(pub ::core::ffi::c_uint);
 impl ArkUI_TextCase {
     /// The original case of the text is retained.
     pub const ARKUI_TEXT_CASE_NORMAL: ArkUI_TextCase = ArkUI_TextCase(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextCase {
     /// All letters in the text are in lowercase.
     pub const ARKUI_TEXT_CASE_LOWER: ArkUI_TextCase = ArkUI_TextCase(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextCase {
     /// All letters in the text are in uppercase.
     pub const ARKUI_TEXT_CASE_UPPER: ArkUI_TextCase = ArkUI_TextCase(2);
 }
@@ -767,22 +515,10 @@ pub struct ArkUI_TextCase(pub ::core::ffi::c_uint);
 impl ArkUI_CopyOptions {
     /// Copy is not allowed.
     pub const ARKUI_COPY_OPTIONS_NONE: ArkUI_CopyOptions = ArkUI_CopyOptions(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_CopyOptions {
     /// Intra-application copy is allowed.
     pub const ARKUI_COPY_OPTIONS_IN_APP: ArkUI_CopyOptions = ArkUI_CopyOptions(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_CopyOptions {
     /// Intra-device copy is allowed.
     pub const ARKUI_COPY_OPTIONS_LOCAL_DEVICE: ArkUI_CopyOptions = ArkUI_CopyOptions(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_CopyOptions {
     /// Cross-device copy is allowed.
     pub const ARKUI_COPY_OPTIONS_CROSS_DEVICE: ArkUI_CopyOptions = ArkUI_CopyOptions(3);
 }
@@ -800,10 +536,6 @@ pub struct ArkUI_CopyOptions(pub ::core::ffi::c_uint);
 impl ArkUI_ShadowType {
     /// Color.
     pub const ARKUI_SHADOW_TYPE_COLOR: ArkUI_ShadowType = ArkUI_ShadowType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ShadowType {
     /// Blur.
     pub const ARKUI_SHADOW_TYPE_BLUR: ArkUI_ShadowType = ArkUI_ShadowType(1);
 }
@@ -822,24 +554,12 @@ impl ArkUI_TextPickerRangeType {
     /// Single-column text picker.
     pub const ARKUI_TEXTPICKER_RANGETYPE_SINGLE: ArkUI_TextPickerRangeType =
         ArkUI_TextPickerRangeType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextPickerRangeType {
     /// Multi-column text picker.
     pub const ARKUI_TEXTPICKER_RANGETYPE_MULTI: ArkUI_TextPickerRangeType =
         ArkUI_TextPickerRangeType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextPickerRangeType {
     /// Single-column text picker with image resources.
     pub const ARKUI_TEXTPICKER_RANGETYPE_RANGE_CONTENT: ArkUI_TextPickerRangeType =
         ArkUI_TextPickerRangeType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextPickerRangeType {
     /// Interconnected multi-column text picker.
     pub const ARKUI_TEXTPICKER_RANGETYPE_CASCADE_RANGE_CONTENT: ArkUI_TextPickerRangeType =
         ArkUI_TextPickerRangeType(3);
@@ -889,16 +609,8 @@ impl ArkUI_EdgeEffect {
     /// Spring effect. When at one of the edges, the component can move beyond the bounds based on the initial
     /// speed or through touches, and produces a bounce effect when the user releases their finger.
     pub const ARKUI_EDGE_EFFECT_SPRING: ArkUI_EdgeEffect = ArkUI_EdgeEffect(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_EdgeEffect {
     /// Fade effect. When at one of the edges, the component produces a fade effect.
     pub const ARKUI_EDGE_EFFECT_FADE: ArkUI_EdgeEffect = ArkUI_EdgeEffect(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_EdgeEffect {
     /// No effect after the scrollbar is moved to the edge.
     pub const ARKUI_EDGE_EFFECT_NONE: ArkUI_EdgeEffect = ArkUI_EdgeEffect(2);
 }
@@ -917,16 +629,8 @@ pub struct ArkUI_EdgeEffect(pub ::core::ffi::c_uint);
 impl ArkUI_ScrollDirection {
     /// Only vertical scrolling is supported.
     pub const ARKUI_SCROLL_DIRECTION_VERTICAL: ArkUI_ScrollDirection = ArkUI_ScrollDirection(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollDirection {
     /// Only horizontal scrolling is supported.
     pub const ARKUI_SCROLL_DIRECTION_HORIZONTAL: ArkUI_ScrollDirection = ArkUI_ScrollDirection(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollDirection {
     /// Scrolling is not allowed.
     pub const ARKUI_SCROLL_DIRECTION_NONE: ArkUI_ScrollDirection = ArkUI_ScrollDirection(3);
 }
@@ -944,22 +648,10 @@ pub struct ArkUI_ScrollDirection(pub ::core::ffi::c_uint);
 impl ArkUI_ScrollSnapAlign {
     /// No alignment. This is the default value.
     pub const ARKUI_SCROLL_SNAP_ALIGN_NONE: ArkUI_ScrollSnapAlign = ArkUI_ScrollSnapAlign(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollSnapAlign {
     /// The first item in the view is aligned at the start of the list.
     pub const ARKUI_SCROLL_SNAP_ALIGN_START: ArkUI_ScrollSnapAlign = ArkUI_ScrollSnapAlign(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollSnapAlign {
     /// The middle items in the view are aligned in the center of the list.
     pub const ARKUI_SCROLL_SNAP_ALIGN_CENTER: ArkUI_ScrollSnapAlign = ArkUI_ScrollSnapAlign(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollSnapAlign {
     /// The last item in the view is aligned at the end of the list.
     pub const ARKUI_SCROLL_SNAP_ALIGN_END: ArkUI_ScrollSnapAlign = ArkUI_ScrollSnapAlign(3);
 }
@@ -978,17 +670,9 @@ impl ArkUI_ScrollBarDisplayMode {
     /// Hide.
     pub const ARKUI_SCROLL_BAR_DISPLAY_MODE_OFF: ArkUI_ScrollBarDisplayMode =
         ArkUI_ScrollBarDisplayMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollBarDisplayMode {
     /// Display on demand (displays when the screen is touched and disappears after 2s).
     pub const ARKUI_SCROLL_BAR_DISPLAY_MODE_AUTO: ArkUI_ScrollBarDisplayMode =
         ArkUI_ScrollBarDisplayMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollBarDisplayMode {
     /// Always display.
     pub const ARKUI_SCROLL_BAR_DISPLAY_MODE_ON: ArkUI_ScrollBarDisplayMode =
         ArkUI_ScrollBarDisplayMode(2);
@@ -1007,10 +691,6 @@ pub struct ArkUI_ScrollBarDisplayMode(pub ::core::ffi::c_uint);
 impl ArkUI_Axis {
     /// Only vertical scrolling is supported.
     pub const ARKUI_AXIS_VERTICAL: ArkUI_Axis = ArkUI_Axis(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Axis {
     /// Only horizontal scrolling is supported.
     pub const ARKUI_AXIS_HORIZONTAL: ArkUI_Axis = ArkUI_Axis(1);
 }
@@ -1028,22 +708,10 @@ pub struct ArkUI_Axis(pub ::core::ffi::c_uint);
 impl ArkUI_StickyStyle {
     /// In the list item group, the header is not pinned to the top, and the footer is not pinned to the bottom.
     pub const ARKUI_STICKY_STYLE_NONE: ArkUI_StickyStyle = ArkUI_StickyStyle(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_StickyStyle {
     /// In the list item group, the header is pinned to the top, and the footer is not pinned to the bottom.
     pub const ARKUI_STICKY_STYLE_HEADER: ArkUI_StickyStyle = ArkUI_StickyStyle(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_StickyStyle {
     /// In the list item group, the footer is pinned to the bottom, and the header is not pinned to the top.
     pub const ARKUI_STICKY_STYLE_FOOTER: ArkUI_StickyStyle = ArkUI_StickyStyle(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_StickyStyle {
     /// In the list item group, the footer is pinned to the bottom, and the header is pinned to the top.
     pub const ARKUI_STICKY_STYLE_BOTH: ArkUI_StickyStyle = ArkUI_StickyStyle(3);
 }
@@ -1061,16 +729,8 @@ pub struct ArkUI_StickyStyle(pub ::core::ffi::c_uint);
 impl ArkUI_BorderStyle {
     /// Solid border.
     pub const ARKUI_BORDER_STYLE_SOLID: ArkUI_BorderStyle = ArkUI_BorderStyle(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BorderStyle {
     /// Dashed border.
     pub const ARKUI_BORDER_STYLE_DASHED: ArkUI_BorderStyle = ArkUI_BorderStyle(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BorderStyle {
     /// Dotted border.
     pub const ARKUI_BORDER_STYLE_DOTTED: ArkUI_BorderStyle = ArkUI_BorderStyle(2);
 }
@@ -1089,24 +749,12 @@ impl ArkUI_HitTestMode {
     /// Both the node and its child node respond to the hit test of a touch event, but its sibling node is blocked from
     /// the hit test.
     pub const ARKUI_HIT_TEST_MODE_DEFAULT: ArkUI_HitTestMode = ArkUI_HitTestMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_HitTestMode {
     /// The node responds to the hit test of a touch event, but its child node and sibling node are blocked from the
     /// hit test.
     pub const ARKUI_HIT_TEST_MODE_BLOCK: ArkUI_HitTestMode = ArkUI_HitTestMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_HitTestMode {
     /// Both the node and its child node respond to the hit test of a touch event, and its sibling node is also
     /// considered during the hit test.
     pub const ARKUI_HIT_TEST_MODE_TRANSPARENT: ArkUI_HitTestMode = ArkUI_HitTestMode(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_HitTestMode {
     /// The node does not respond to the hit test of a touch event.
     pub const ARKUI_HIT_TEST_MODE_NONE: ArkUI_HitTestMode = ArkUI_HitTestMode(3);
 }
@@ -1124,34 +772,14 @@ pub struct ArkUI_HitTestMode(pub ::core::ffi::c_uint);
 impl ArkUI_ShadowStyle {
     /// Mini shadow.
     pub const ARKUI_SHADOW_STYLE_OUTER_DEFAULT_XS: ArkUI_ShadowStyle = ArkUI_ShadowStyle(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ShadowStyle {
     /// Little shadow.
     pub const ARKUI_SHADOW_STYLE_OUTER_DEFAULT_SM: ArkUI_ShadowStyle = ArkUI_ShadowStyle(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ShadowStyle {
     /// Medium shadow.
     pub const ARKUI_SHADOW_STYLE_OUTER_DEFAULT_MD: ArkUI_ShadowStyle = ArkUI_ShadowStyle(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ShadowStyle {
     /// Large shadow.
     pub const ARKUI_SHADOW_STYLE_OUTER_DEFAULT_LG: ArkUI_ShadowStyle = ArkUI_ShadowStyle(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ShadowStyle {
     /// Floating small shadow.
     pub const ARKUI_SHADOW_STYLE_OUTER_FLOATING_SM: ArkUI_ShadowStyle = ArkUI_ShadowStyle(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ShadowStyle {
     /// Floating medium shadow.
     pub const ARKUI_SHADOW_STYLE_OUTER_FLOATING_MD: ArkUI_ShadowStyle = ArkUI_ShadowStyle(5);
 }
@@ -1169,76 +797,28 @@ pub struct ArkUI_ShadowStyle(pub ::core::ffi::c_uint);
 impl ArkUI_AnimationCurve {
     /// The animation speed keeps unchanged.
     pub const ARKUI_CURVE_LINEAR: ArkUI_AnimationCurve = ArkUI_AnimationCurve(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation starts slowly, accelerates, and then slows down towards the end.
     pub const ARKUI_CURVE_EASE: ArkUI_AnimationCurve = ArkUI_AnimationCurve(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation starts at a low speed and then picks up speed until the end.
     pub const ARKUI_CURVE_EASE_IN: ArkUI_AnimationCurve = ArkUI_AnimationCurve(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation ends at a low speed.
     pub const ARKUI_CURVE_EASE_OUT: ArkUI_AnimationCurve = ArkUI_AnimationCurve(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation starts and ends at a low speed.
     pub const ARKUI_CURVE_EASE_IN_OUT: ArkUI_AnimationCurve = ArkUI_AnimationCurve(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation uses the standard curve
     pub const ARKUI_CURVE_FAST_OUT_SLOW_IN: ArkUI_AnimationCurve = ArkUI_AnimationCurve(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation uses the deceleration curve.
     pub const ARKUI_CURVE_LINEAR_OUT_SLOW_IN: ArkUI_AnimationCurve = ArkUI_AnimationCurve(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation uses the acceleration curve.
     pub const ARKUI_CURVE_FAST_OUT_LINEAR_IN: ArkUI_AnimationCurve = ArkUI_AnimationCurve(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation uses the extreme deceleration curve.
     pub const ARKUI_CURVE_EXTREME_DECELERATION: ArkUI_AnimationCurve = ArkUI_AnimationCurve(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation uses the sharp curve.
     pub const ARKUI_CURVE_SHARP: ArkUI_AnimationCurve = ArkUI_AnimationCurve(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation uses the rhythm curve.
     pub const ARKUI_CURVE_RHYTHM: ArkUI_AnimationCurve = ArkUI_AnimationCurve(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation uses the smooth curve.
     pub const ARKUI_CURVE_SMOOTH: ArkUI_AnimationCurve = ArkUI_AnimationCurve(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationCurve {
     /// The animation uses the friction curve
     pub const ARKUI_CURVE_FRICTION: ArkUI_AnimationCurve = ArkUI_AnimationCurve(12);
 }
@@ -1256,16 +836,8 @@ pub struct ArkUI_AnimationCurve(pub ::core::ffi::c_uint);
 impl ArkUI_SwiperArrow {
     /// The arrow is not displayed for the navigation point indicator.
     pub const ARKUI_SWIPER_ARROW_HIDE: ArkUI_SwiperArrow = ArkUI_SwiperArrow(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SwiperArrow {
     /// The arrow is displayed for the navigation point indicator.
     pub const ARKUI_SWIPER_ARROW_SHOW: ArkUI_SwiperArrow = ArkUI_SwiperArrow(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SwiperArrow {
     /// The arrow is displayed only when the mouse pointer hovers over the navigation point indicator.
     pub const ARKUI_SWIPER_ARROW_SHOW_ON_HOVER: ArkUI_SwiperArrow = ArkUI_SwiperArrow(2);
 }
@@ -1284,10 +856,6 @@ impl ArkUI_SwiperNestedScrollMode {
     /// Swiper only scrolls on its own and is not linked to its parent component.
     pub const ARKUI_SWIPER_NESTED_SRCOLL_SELF_ONLY: ArkUI_SwiperNestedScrollMode =
         ArkUI_SwiperNestedScrollMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SwiperNestedScrollMode {
     /// The Swiper itself scrolls first, and the parent component scrolls after it reaches the edge. After the parent
     /// component scrolls to the edge, if the parent component has an edge effect, the parent component triggers the edge
     /// effect; otherwise, the Swiper triggers the edge effect.
@@ -1308,24 +876,12 @@ pub struct ArkUI_SwiperNestedScrollMode(pub ::core::ffi::c_uint);
 impl ArkUI_AccessibilityMode {
     /// Whether the component can be identified by the accessibility service is dependent on the component.
     pub const ARKUI_ACCESSIBILITY_MODE_AUTO: ArkUI_AccessibilityMode = ArkUI_AccessibilityMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AccessibilityMode {
     /// The component can be identified by the accessibility service.
     pub const ARKUI_ACCESSIBILITY_MODE_ENABLED: ArkUI_AccessibilityMode =
         ArkUI_AccessibilityMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AccessibilityMode {
     /// The component cannot be identified by the accessibility service.
     pub const ARKUI_ACCESSIBILITY_MODE_DISABLED: ArkUI_AccessibilityMode =
         ArkUI_AccessibilityMode(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AccessibilityMode {
     /// The component and all its child components cannot be identified by the accessibility service.
     pub const ARKUI_ACCESSIBILITY_MODE_DISABLED_FOR_DESCENDANTS: ArkUI_AccessibilityMode =
         ArkUI_AccessibilityMode(3);
@@ -1344,23 +900,11 @@ pub struct ArkUI_AccessibilityMode(pub ::core::ffi::c_uint);
 impl ArkUI_TextCopyOptions {
     /// Copy is not allowed.
     pub const ARKUI_TEXT_COPY_OPTIONS_NONE: ArkUI_TextCopyOptions = ArkUI_TextCopyOptions(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextCopyOptions {
     /// Intra-application copy is allowed.
     pub const ARKUI_TEXT_COPY_OPTIONS_IN_APP: ArkUI_TextCopyOptions = ArkUI_TextCopyOptions(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextCopyOptions {
     /// Intra-device copy is allowed.
     pub const ARKUI_TEXT_COPY_OPTIONS_LOCAL_DEVICE: ArkUI_TextCopyOptions =
         ArkUI_TextCopyOptions(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextCopyOptions {
     /// Cross-device copy is allowed.
     pub const ARKUI_TEXT_COPY_OPTIONS_CROSS_DEVICE: ArkUI_TextCopyOptions =
         ArkUI_TextCopyOptions(3);
@@ -1380,17 +924,9 @@ impl ArkUI_TextHeightAdaptivePolicy {
     /// Prioritize the <b>maxLines</b> settings.
     pub const ARKUI_TEXT_HEIGHT_ADAPTIVE_POLICY_MAX_LINES_FIRST: ArkUI_TextHeightAdaptivePolicy =
         ArkUI_TextHeightAdaptivePolicy(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextHeightAdaptivePolicy {
     /// Prioritize the <b>minFontSize</b> settings.
     pub const ARKUI_TEXT_HEIGHT_ADAPTIVE_POLICY_MIN_FONT_SIZE_FIRST:
         ArkUI_TextHeightAdaptivePolicy = ArkUI_TextHeightAdaptivePolicy(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextHeightAdaptivePolicy {
     /// Prioritize the layout constraint settings in terms of height.
     pub const ARKUI_TEXT_HEIGHT_ADAPTIVE_POLICY_LAYOUT_CONSTRAINT_FIRST:
         ArkUI_TextHeightAdaptivePolicy = ArkUI_TextHeightAdaptivePolicy(2);
@@ -1411,28 +947,16 @@ impl ArkUI_ScrollNestedMode {
     /// does not scroll when the component scrolling reaches the boundary.
     pub const ARKUI_SCROLL_NESTED_MODE_SELF_ONLY: ArkUI_ScrollNestedMode =
         ArkUI_ScrollNestedMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollNestedMode {
     /// The component scrolls first, and when it hits the boundary, the parent component scrolls.
     /// When the parent component hits the boundary, its edge effect is displayed. If no edge
     /// effect is specified for the parent component, the edge effect of the child component is displayed instead.
     pub const ARKUI_SCROLL_NESTED_MODE_SELF_FIRST: ArkUI_ScrollNestedMode =
         ArkUI_ScrollNestedMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollNestedMode {
     /// The parent component scrolls first, and when it hits the boundary, the component scrolls.
     /// When the component hits the boundary, its edge effect is displayed. If no edge effect is specified for the
     /// component, the edge effect of the parent component is displayed instead.
     pub const ARKUI_SCROLL_NESTED_MODE_PARENT_FIRST: ArkUI_ScrollNestedMode =
         ArkUI_ScrollNestedMode(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollNestedMode {
     /// The component and its parent component scroll at the same time. When both the component and its parent component
     /// hit the boundary, the edge effect of the component is displayed. If no edge effect is specified for the
     /// component, the edge effect of the parent component is displayed instead.
@@ -1452,22 +976,10 @@ pub struct ArkUI_ScrollNestedMode(pub ::core::ffi::c_uint);
 impl ArkUI_ScrollEdge {
     /// Top edge in the vertical direction.
     pub const ARKUI_SCROLL_EDGE_TOP: ArkUI_ScrollEdge = ArkUI_ScrollEdge(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollEdge {
     /// Bottom edge in the vertical direction.
     pub const ARKUI_SCROLL_EDGE_BOTTOM: ArkUI_ScrollEdge = ArkUI_ScrollEdge(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollEdge {
     /// Start position in the horizontal direction.
     pub const ARKUI_SCROLL_EDGE_START: ArkUI_ScrollEdge = ArkUI_ScrollEdge(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollEdge {
     /// End position in the horizontal direction.
     pub const ARKUI_SCROLL_EDGE_END: ArkUI_ScrollEdge = ArkUI_ScrollEdge(3);
 }
@@ -1485,22 +997,10 @@ pub struct ArkUI_ScrollEdge(pub ::core::ffi::c_uint);
 impl ArkUI_ScrollAlignment {
     /// Align the head. Align the head of the specified item with the head of the container.
     pub const ARKUI_SCROLL_ALIGNMENT_START: ArkUI_ScrollAlignment = ArkUI_ScrollAlignment(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollAlignment {
     /// Center alignment. Align the axis direction of the specified item to the center of the container.
     pub const ARKUI_SCROLL_ALIGNMENT_CENTER: ArkUI_ScrollAlignment = ArkUI_ScrollAlignment(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollAlignment {
     /// Tail alignment. Align the tail of the specified item with the tail of the container.
     pub const ARKUI_SCROLL_ALIGNMENT_END: ArkUI_ScrollAlignment = ArkUI_ScrollAlignment(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollAlignment {
     /// Automatic alignment. If the specified item is completely in the display area, no adjustments will be made.
     /// Otherwise, according to the principle of the shortest sliding distance, align the head or tail of the specified
     /// item with the container, so that the specified item is completely in the display area.
@@ -1521,16 +1021,8 @@ impl ArkUI_ScrollState {
     /// Idle state. Trigger when using the method provided by the controller to control scrolling, and trigger when
     /// dragging the scroll bar to scroll.
     pub const ARKUI_SCROLL_STATE_IDLE: ArkUI_ScrollState = ArkUI_ScrollState(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollState {
     /// Scroll state. Triggered when dragging the container with fingers to scroll.
     pub const ARKUI_SCROLL_STATE_SCROLL: ArkUI_ScrollState = ArkUI_ScrollState(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollState {
     /// Inertial rolling state. Triggered when inertia rolling and bouncing back to the edge are performed after
     /// releasing the hand quickly.
     pub const ARKUI_SCROLL_STATE_FLING: ArkUI_ScrollState = ArkUI_ScrollState(2);
@@ -1549,16 +1041,8 @@ pub struct ArkUI_ScrollState(pub ::core::ffi::c_uint);
 impl ArkUI_SliderBlockStyle {
     /// Round slider.
     pub const ARKUI_SLIDER_BLOCK_STYLE_DEFAULT: ArkUI_SliderBlockStyle = ArkUI_SliderBlockStyle(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SliderBlockStyle {
     /// Slider with an image background.
     pub const ARKUI_SLIDER_BLOCK_STYLE_IMAGE: ArkUI_SliderBlockStyle = ArkUI_SliderBlockStyle(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SliderBlockStyle {
     /// Slider in a custom shape.
     pub const ARKUI_SLIDER_BLOCK_STYLE_SHAPE: ArkUI_SliderBlockStyle = ArkUI_SliderBlockStyle(2);
 }
@@ -1576,10 +1060,6 @@ pub struct ArkUI_SliderBlockStyle(pub ::core::ffi::c_uint);
 impl ArkUI_SliderDirection {
     /// Vertical direction.
     pub const ARKUI_SLIDER_DIRECTION_VERTICAL: ArkUI_SliderDirection = ArkUI_SliderDirection(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SliderDirection {
     /// Horizontal direction.
     pub const ARKUI_SLIDER_DIRECTION_HORIZONTAL: ArkUI_SliderDirection = ArkUI_SliderDirection(1);
 }
@@ -1597,16 +1077,8 @@ pub struct ArkUI_SliderDirection(pub ::core::ffi::c_uint);
 impl ArkUI_SliderStyle {
     /// The slider is on the slider track.
     pub const ARKUI_SLIDER_STYLE_OUT_SET: ArkUI_SliderStyle = ArkUI_SliderStyle(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SliderStyle {
     /// The slider is in the slider track.
     pub const ARKUI_SLIDER_STYLE_IN_SET: ArkUI_SliderStyle = ArkUI_SliderStyle(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SliderStyle {
     /// No slider.
     pub const ARKUI_SLIDER_STYLE_NONE: ArkUI_SliderStyle = ArkUI_SliderStyle(2);
 }
@@ -1624,10 +1096,6 @@ pub struct ArkUI_SliderStyle(pub ::core::ffi::c_uint);
 impl ArkUI_CheckboxShape {
     /// Circle.
     pub const ArkUI_CHECKBOX_SHAPE_CIRCLE: ArkUI_CheckboxShape = ArkUI_CheckboxShape(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_CheckboxShape {
     /// Rounded square.
     pub const ArkUI_CHECKBOX_SHAPE_ROUNDED_SQUARE: ArkUI_CheckboxShape = ArkUI_CheckboxShape(1);
 }
@@ -1646,25 +1114,13 @@ impl ArkUI_AnimationPlayMode {
     /// The animation is played forwards.
     pub const ARKUI_ANIMATION_PLAY_MODE_NORMAL: ArkUI_AnimationPlayMode =
         ArkUI_AnimationPlayMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationPlayMode {
     /// The animation is played reversely.
     pub const ARKUI_ANIMATION_PLAY_MODE_REVERSE: ArkUI_AnimationPlayMode =
         ArkUI_AnimationPlayMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationPlayMode {
     /// The animation is played normally for an odd number of times (1, 3, 5...) and reversely for an even number
     /// of times (2, 4, 6...).
     pub const ARKUI_ANIMATION_PLAY_MODE_ALTERNATE: ArkUI_AnimationPlayMode =
         ArkUI_AnimationPlayMode(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationPlayMode {
     /// The animation is played reversely for an odd number of times (1, 3, 5...) and normally for an even number
     /// of times (2, 4, 6...).
     pub const ARKUI_ANIMATION_PLAY_MODE_ALTERNATE_REVERSE: ArkUI_AnimationPlayMode =
@@ -1684,17 +1140,9 @@ pub struct ArkUI_AnimationPlayMode(pub ::core::ffi::c_uint);
 impl ArkUI_ImageSize {
     /// The original image aspect ratio is retained.
     pub const ARKUI_IMAGE_SIZE_AUTO: ArkUI_ImageSize = ArkUI_ImageSize(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageSize {
     /// Default value. The image is scaled with its aspect ratio retained for both sides to be greater than or equal
     /// to the display boundaries.
     pub const ARKUI_IMAGE_SIZE_COVER: ArkUI_ImageSize = ArkUI_ImageSize(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageSize {
     /// The image is scaled with its aspect ratio retained for the content to be completely displayed within the display
     /// boundaries.
     pub const ARKUI_IMAGE_SIZE_CONTAIN: ArkUI_ImageSize = ArkUI_ImageSize(2);
@@ -1713,10 +1161,6 @@ pub struct ArkUI_ImageSize(pub ::core::ffi::c_uint);
 impl ArkUI_AdaptiveColor {
     /// Adaptive color mode is not used.
     pub const ARKUI_ADAPTIVE_COLOR_DEFAULT: ArkUI_AdaptiveColor = ArkUI_AdaptiveColor(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AdaptiveColor {
     /// Adaptive color mode is used.
     pub const ARKUI_ADAPTIVE_COLOR_AVERAGE: ArkUI_AdaptiveColor = ArkUI_AdaptiveColor(1);
 }
@@ -1734,16 +1178,8 @@ pub struct ArkUI_AdaptiveColor(pub ::core::ffi::c_uint);
 impl ArkUI_ColorMode {
     /// Following the system color mode.
     pub const ARKUI_COLOR_MODE_SYSTEM: ArkUI_ColorMode = ArkUI_ColorMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ColorMode {
     /// Light color mode.
     pub const ARKUI_COLOR_MODE_LIGHT: ArkUI_ColorMode = ArkUI_ColorMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ColorMode {
     /// Dark color mode.
     pub const ARKUI_COLOR_MODE_DARK: ArkUI_ColorMode = ArkUI_ColorMode(2);
 }
@@ -1761,10 +1197,6 @@ pub struct ArkUI_ColorMode(pub ::core::ffi::c_uint);
 impl ArkUI_SystemColorMode {
     /// Light color mode.
     pub const ARKUI_SYSTEM_COLOR_MODE_LIGHT: ArkUI_SystemColorMode = ArkUI_SystemColorMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SystemColorMode {
     /// Dark color mode.
     pub const ARKUI_SYSTEM_COLOR_MODE_DARK: ArkUI_SystemColorMode = ArkUI_SystemColorMode(1);
 }
@@ -1782,76 +1214,28 @@ pub struct ArkUI_SystemColorMode(pub ::core::ffi::c_uint);
 impl ArkUI_BlurStyle {
     /// Thin material.
     pub const ARKUI_BLUR_STYLE_THIN: ArkUI_BlurStyle = ArkUI_BlurStyle(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// Regular material.
     pub const ARKUI_BLUR_STYLE_REGULAR: ArkUI_BlurStyle = ArkUI_BlurStyle(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// Thick material.
     pub const ARKUI_BLUR_STYLE_THICK: ArkUI_BlurStyle = ArkUI_BlurStyle(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// Material that creates the minimum depth of field effect.
     pub const ARKUI_BLUR_STYLE_BACKGROUND_THIN: ArkUI_BlurStyle = ArkUI_BlurStyle(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// Material that creates a medium shallow depth of field effect.
     pub const ARKUI_BLUR_STYLE_BACKGROUND_REGULAR: ArkUI_BlurStyle = ArkUI_BlurStyle(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// Material that creates a high shallow depth of field effect.
     pub const ARKUI_BLUR_STYLE_BACKGROUND_THICK: ArkUI_BlurStyle = ArkUI_BlurStyle(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// Material that creates the maximum depth of field effect.
     pub const ARKUI_BLUR_STYLE_BACKGROUND_ULTRA_THICK: ArkUI_BlurStyle = ArkUI_BlurStyle(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// No blur.
     pub const ARKUI_BLUR_STYLE_NONE: ArkUI_BlurStyle = ArkUI_BlurStyle(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// Component ultra-thin material.
     pub const ARKUI_BLUR_STYLE_COMPONENT_ULTRA_THIN: ArkUI_BlurStyle = ArkUI_BlurStyle(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// Component thin material.
     pub const ARKUI_BLUR_STYLE_COMPONENT_THIN: ArkUI_BlurStyle = ArkUI_BlurStyle(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// Component regular material.
     pub const ARKUI_BLUR_STYLE_COMPONENT_REGULAR: ArkUI_BlurStyle = ArkUI_BlurStyle(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// Component thick material.
     pub const ARKUI_BLUR_STYLE_COMPONENT_THICK: ArkUI_BlurStyle = ArkUI_BlurStyle(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlurStyle {
     /// Component ultra-thick material.
     pub const ARKUI_BLUR_STYLE_COMPONENT_ULTRA_THICK: ArkUI_BlurStyle = ArkUI_BlurStyle(12);
 }
@@ -1869,16 +1253,8 @@ pub struct ArkUI_BlurStyle(pub ::core::ffi::c_uint);
 impl ArkUI_VerticalAlignment {
     /// Top aligned.
     pub const ARKUI_VERTICAL_ALIGNMENT_TOP: ArkUI_VerticalAlignment = ArkUI_VerticalAlignment(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_VerticalAlignment {
     /// Center aligned. This is the default alignment mode.
     pub const ARKUI_VERTICAL_ALIGNMENT_CENTER: ArkUI_VerticalAlignment = ArkUI_VerticalAlignment(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_VerticalAlignment {
     /// Bottom aligned.
     pub const ARKUI_VERTICAL_ALIGNMENT_BOTTOM: ArkUI_VerticalAlignment = ArkUI_VerticalAlignment(2);
 }
@@ -1897,17 +1273,9 @@ impl ArkUI_HorizontalAlignment {
     /// Aligned with the start edge in the same direction as the language in use.
     pub const ARKUI_HORIZONTAL_ALIGNMENT_START: ArkUI_HorizontalAlignment =
         ArkUI_HorizontalAlignment(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_HorizontalAlignment {
     /// Center aligned. This is the default alignment mode.
     pub const ARKUI_HORIZONTAL_ALIGNMENT_CENTER: ArkUI_HorizontalAlignment =
         ArkUI_HorizontalAlignment(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_HorizontalAlignment {
     /// Aligned with the end edge in the same direction as the language in use.
     pub const ARKUI_HORIZONTAL_ALIGNMENT_END: ArkUI_HorizontalAlignment =
         ArkUI_HorizontalAlignment(2);
@@ -1926,22 +1294,10 @@ pub struct ArkUI_HorizontalAlignment(pub ::core::ffi::c_uint);
 impl ArkUI_TextOverflow {
     /// Extra-long text is not clipped.
     pub const ARKUI_TEXT_OVERFLOW_NONE: ArkUI_TextOverflow = ArkUI_TextOverflow(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextOverflow {
     /// Extra-long text is clipped.
     pub const ARKUI_TEXT_OVERFLOW_CLIP: ArkUI_TextOverflow = ArkUI_TextOverflow(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextOverflow {
     /// An ellipsis (...) is used to represent text overflow.
     pub const ARKUI_TEXT_OVERFLOW_ELLIPSIS: ArkUI_TextOverflow = ArkUI_TextOverflow(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextOverflow {
     /// Text continuously scrolls when text overflow occurs.
     pub const ARKUI_TEXT_OVERFLOW_MARQUEE: ArkUI_TextOverflow = ArkUI_TextOverflow(3);
 }
@@ -1960,24 +1316,12 @@ impl ArkUI_ImageSpanAlignment {
     /// The image is bottom aligned with the text baseline.
     pub const ARKUI_IMAGE_SPAN_ALIGNMENT_BASELINE: ArkUI_ImageSpanAlignment =
         ArkUI_ImageSpanAlignment(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageSpanAlignment {
     /// The image is bottom aligned with the text.
     pub const ARKUI_IMAGE_SPAN_ALIGNMENT_BOTTOM: ArkUI_ImageSpanAlignment =
         ArkUI_ImageSpanAlignment(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageSpanAlignment {
     /// The image is centered aligned with the text.
     pub const ARKUI_IMAGE_SPAN_ALIGNMENT_CENTER: ArkUI_ImageSpanAlignment =
         ArkUI_ImageSpanAlignment(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageSpanAlignment {
     /// The image is top aligned with the text.
     pub const ARKUI_IMAGE_SPAN_ALIGNMENT_TOP: ArkUI_ImageSpanAlignment =
         ArkUI_ImageSpanAlignment(3);
@@ -1997,90 +1341,34 @@ impl ArkUI_ObjectFit {
     /// The image is scaled with its aspect ratio retained for the content to be completely displayed within the
     /// display boundaries.
     pub const ARKUI_OBJECT_FIT_CONTAIN: ArkUI_ObjectFit = ArkUI_ObjectFit(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// The image is scaled with its aspect ratio retained for both sides to be greater than or equal to the
     /// display boundaries.
     pub const ARKUI_OBJECT_FIT_COVER: ArkUI_ObjectFit = ArkUI_ObjectFit(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// The image is scaled automatically to fit the display area.
     pub const ARKUI_OBJECT_FIT_AUTO: ArkUI_ObjectFit = ArkUI_ObjectFit(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// The image is scaled to fill the display area, and its aspect ratio is not retained.
     pub const ARKUI_OBJECT_FIT_FILL: ArkUI_ObjectFit = ArkUI_ObjectFit(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// The image content is displayed with its aspect ratio retained. The size is smaller than or equal to the
     /// original size.
     pub const ARKUI_OBJECT_FIT_SCALE_DOWN: ArkUI_ObjectFit = ArkUI_ObjectFit(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// The original size is retained.
     pub const ARKUI_OBJECT_FIT_NONE: ArkUI_ObjectFit = ArkUI_ObjectFit(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// Not resized, the image is aligned with the start edge of the top of the container.
     pub const ARKUI_OBJECT_FIT_NONE_AND_ALIGN_TOP_START: ArkUI_ObjectFit = ArkUI_ObjectFit(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// Not resized, the image is horizontally centered at the top of the container.
     pub const ARKUI_OBJECT_FIT_NONE_AND_ALIGN_TOP: ArkUI_ObjectFit = ArkUI_ObjectFit(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// Not resized, the image is aligned with the end edge at the top of the container.
     pub const ARKUI_OBJECT_FIT_NONE_AND_ALIGN_TOP_END: ArkUI_ObjectFit = ArkUI_ObjectFit(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// Not resized, the image is vertically centered on the start edge of the container.
     pub const ARKUI_OBJECT_FIT_NONE_AND_ALIGN_START: ArkUI_ObjectFit = ArkUI_ObjectFit(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// Not resized, the image is horizontally and vertically centered in the container.
     pub const ARKUI_OBJECT_FIT_NONE_AND_ALIGN_CENTER: ArkUI_ObjectFit = ArkUI_ObjectFit(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// Not resized, the image is vertically centered on the end edge of the container.
     pub const ARKUI_OBJECT_FIT_NONE_AND_ALIGN_END: ArkUI_ObjectFit = ArkUI_ObjectFit(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// Not resized, the image is aligned with the start edge at the bottom of the container.
     pub const ARKUI_OBJECT_FIT_NONE_AND_ALIGN_BOTTOM_START: ArkUI_ObjectFit = ArkUI_ObjectFit(12);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// Not resized, the image is horizontally centered at the bottom of the container.
     pub const ARKUI_OBJECT_FIT_NONE_AND_ALIGN_BOTTOM: ArkUI_ObjectFit = ArkUI_ObjectFit(13);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ObjectFit {
     /// Not resized, the image is aligned with the end edge at the bottom of the container.
     pub const ARKUI_OBJECT_FIT_NONE_AND_ALIGN_BOTTOM_END: ArkUI_ObjectFit = ArkUI_ObjectFit(14);
 }
@@ -2099,23 +1387,11 @@ impl ArkUI_ImageInterpolation {
     /// No image interpolation.
     pub const ARKUI_IMAGE_INTERPOLATION_NONE: ArkUI_ImageInterpolation =
         ArkUI_ImageInterpolation(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageInterpolation {
     /// Low quality interpolation.
     pub const ARKUI_IMAGE_INTERPOLATION_LOW: ArkUI_ImageInterpolation = ArkUI_ImageInterpolation(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageInterpolation {
     /// Medium quality interpolation.
     pub const ARKUI_IMAGE_INTERPOLATION_MEDIUM: ArkUI_ImageInterpolation =
         ArkUI_ImageInterpolation(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageInterpolation {
     /// High quality interpolation. This mode produces scaled images of the highest possible quality.
     pub const ARKUI_IMAGE_INTERPOLATION_HIGH: ArkUI_ImageInterpolation =
         ArkUI_ImageInterpolation(3);
@@ -2134,189 +1410,73 @@ pub struct ArkUI_ImageInterpolation(pub ::core::ffi::c_uint);
 impl ArkUI_BlendMode {
     /// The top image is superimposed on the bottom image without any blending.
     pub const ARKUI_BLEND_MODE_NONE: ArkUI_BlendMode = ArkUI_BlendMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// The target pixels covered by the source pixels are erased by being turned to completely transparent.
     pub const ARKUI_BLEND_MODE_CLEAR: ArkUI_BlendMode = ArkUI_BlendMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = s: Only the source pixels are displayed.
     pub const ARKUI_BLEND_MODE_SRC: ArkUI_BlendMode = ArkUI_BlendMode(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = d: Only the target pixels are displayed.
     pub const ARKUI_BLEND_MODE_DST: ArkUI_BlendMode = ArkUI_BlendMode(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = s + (1 - sa) * d: The source pixels are blended based on opacity and cover the target pixels.
     pub const ARKUI_BLEND_MODE_SRC_OVER: ArkUI_BlendMode = ArkUI_BlendMode(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = d + (1 - da) * s: The target pixels are blended based on opacity and cover on the source pixels.
     pub const ARKUI_BLEND_MODE_DST_OVER: ArkUI_BlendMode = ArkUI_BlendMode(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = s * da: Only the part of the source pixels that overlap with the target pixels is displayed.
     pub const ARKUI_BLEND_MODE_SRC_IN: ArkUI_BlendMode = ArkUI_BlendMode(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = d * sa: Only the part of the target pixels that overlap with the source pixels is displayed.
     pub const ARKUI_BLEND_MODE_DST_IN: ArkUI_BlendMode = ArkUI_BlendMode(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = s * (1 - da): Only the part of the source pixels that do not overlap with the target pixels is displayed.
     pub const ARKUI_BLEND_MODE_SRC_OUT: ArkUI_BlendMode = ArkUI_BlendMode(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = d * (1 - sa): Only the part of the target pixels that do not overlap with the source pixels is displayed.
     pub const ARKUI_BLEND_MODE_DST_OUT: ArkUI_BlendMode = ArkUI_BlendMode(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = s * da + d * (1 - sa): The part of the source pixels that overlap with the target pixels is displayed and
     /// the part of the target pixels that do not overlap with the source pixels are displayed.
     pub const ARKUI_BLEND_MODE_SRC_ATOP: ArkUI_BlendMode = ArkUI_BlendMode(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = d * sa + s * (1 - da): The part of the target pixels that overlap with the source pixels and the part of
     /// the source pixels that do not overlap with the target pixels are displayed.
     pub const ARKUI_BLEND_MODE_DST_ATOP: ArkUI_BlendMode = ArkUI_BlendMode(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = s * (1 - da) + d * (1 - sa): Only the non-overlapping part between the source pixels and the target pixels
     /// is displayed.
     pub const ARKUI_BLEND_MODE_XOR: ArkUI_BlendMode = ArkUI_BlendMode(12);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = min(s + d, 1): New pixels resulting from adding the source pixels to the target pixels are displayed.
     pub const ARKUI_BLEND_MODE_PLUS: ArkUI_BlendMode = ArkUI_BlendMode(13);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = s * d: New pixels resulting from multiplying the source pixels with the target pixels are displayed.
     pub const ARKUI_BLEND_MODE_MODULATE: ArkUI_BlendMode = ArkUI_BlendMode(14);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = s + d - s * d: Pixels are blended by adding the source pixels to the target pixels and subtracting the
     /// product of their multiplication.
     pub const ARKUI_BLEND_MODE_SCREEN: ArkUI_BlendMode = ArkUI_BlendMode(15);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// The MULTIPLY or SCREEN mode is used based on the target pixels.
     pub const ARKUI_BLEND_MODE_OVERLAY: ArkUI_BlendMode = ArkUI_BlendMode(16);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// rc = s + d - max(s * da, d * sa), ra = kSrcOver: When two colors overlap, whichever is darker is used.
     pub const ARKUI_BLEND_MODE_DARKEN: ArkUI_BlendMode = ArkUI_BlendMode(17);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// rc = s + d - min(s * da, d * sa), ra =
     /// kSrcOver: The final pixels are composed of the lightest values of pixels.
     pub const ARKUI_BLEND_MODE_LIGHTEN: ArkUI_BlendMode = ArkUI_BlendMode(18);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// The colors of the target pixels are lightened to reflect the source pixels.
     pub const ARKUI_BLEND_MODE_COLOR_DODGE: ArkUI_BlendMode = ArkUI_BlendMode(19);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// The colors of the target pixels are darkened to reflect the source pixels.
     pub const ARKUI_BLEND_MODE_COLOR_BURN: ArkUI_BlendMode = ArkUI_BlendMode(20);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// The MULTIPLY or SCREEN mode is used, depending on the source pixels.
     pub const ARKUI_BLEND_MODE_HARD_LIGHT: ArkUI_BlendMode = ArkUI_BlendMode(21);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// The LIGHTEN or DARKEN mode is used, depending on the source pixels.
     pub const ARKUI_BLEND_MODE_SOFT_LIGHT: ArkUI_BlendMode = ArkUI_BlendMode(22);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// rc = s + d - 2 * (min(s * da, d * sa)), ra =
     /// kSrcOver: The final pixel is the result of subtracting the darker of the two pixels (source and target) from
     /// the lighter one.
     pub const ARKUI_BLEND_MODE_DIFFERENCE: ArkUI_BlendMode = ArkUI_BlendMode(23);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// rc = s + d - two(s * d), ra = kSrcOver: The final pixel is similar to <b>DIFFERENCE</b>, but with less contrast.
     pub const ARKUI_BLEND_MODE_EXCLUSION: ArkUI_BlendMode = ArkUI_BlendMode(24);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// r = s * (1 - da) + d * (1 - sa) + s * d: The final pixel is the result of multiplying the source pixel
     /// by the target pixel.
     pub const ARKUI_BLEND_MODE_MULTIPLY: ArkUI_BlendMode = ArkUI_BlendMode(25);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// The resultant image is created with the luminance and saturation of the source image and the hue of the target
     /// image.
     pub const ARKUI_BLEND_MODE_HUE: ArkUI_BlendMode = ArkUI_BlendMode(26);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// The resultant image is created with the luminance and hue of the target image and the saturation of the source
     /// image.
     pub const ARKUI_BLEND_MODE_SATURATION: ArkUI_BlendMode = ArkUI_BlendMode(27);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// The resultant image is created with the saturation and hue of the source image and the luminance of the target
     /// image.
     pub const ARKUI_BLEND_MODE_COLOR: ArkUI_BlendMode = ArkUI_BlendMode(28);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendMode {
     /// The resultant image is created with the saturation and hue of the target image and the luminance of the source
     /// image.
     pub const ARKUI_BLEND_MODE_LUMINOSITY: ArkUI_BlendMode = ArkUI_BlendMode(29);
@@ -2335,16 +1495,8 @@ pub struct ArkUI_BlendMode(pub ::core::ffi::c_uint);
 impl ArkUI_Direction {
     /// Components are arranged from left to right.
     pub const ARKUI_DIRECTION_LTR: ArkUI_Direction = ArkUI_Direction(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Direction {
     /// Components are arranged from right to left.
     pub const ARKUI_DIRECTION_RTL: ArkUI_Direction = ArkUI_Direction(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Direction {
     /// The default layout direction is used.
     pub const ARKUI_DIRECTION_AUTO: ArkUI_Direction = ArkUI_Direction(3);
 }
@@ -2362,34 +1514,14 @@ pub struct ArkUI_Direction(pub ::core::ffi::c_uint);
 impl ArkUI_ItemAlignment {
     /// The default configuration in the container is used.
     pub const ARKUI_ITEM_ALIGNMENT_AUTO: ArkUI_ItemAlignment = ArkUI_ItemAlignment(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ItemAlignment {
     /// The items in the container are aligned with the cross-start edge.
     pub const ARKUI_ITEM_ALIGNMENT_START: ArkUI_ItemAlignment = ArkUI_ItemAlignment(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ItemAlignment {
     /// The items in the container are centered along the cross axis.
     pub const ARKUI_ITEM_ALIGNMENT_CENTER: ArkUI_ItemAlignment = ArkUI_ItemAlignment(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ItemAlignment {
     /// The items in the container are aligned with the cross-end edge.
     pub const ARKUI_ITEM_ALIGNMENT_END: ArkUI_ItemAlignment = ArkUI_ItemAlignment(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ItemAlignment {
     /// The items in the container are stretched and padded along the cross axis.
     pub const ARKUI_ITEM_ALIGNMENT_STRETCH: ArkUI_ItemAlignment = ArkUI_ItemAlignment(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ItemAlignment {
     /// The items in the container are aligned in such a manner that their text baselines are aligned along the
     /// cross axis.
     pub const ARKUI_ITEM_ALIGNMENT_BASELINE: ArkUI_ItemAlignment = ArkUI_ItemAlignment(5);
@@ -2408,16 +1540,8 @@ pub struct ArkUI_ItemAlignment(pub ::core::ffi::c_uint);
 impl ArkUI_ColorStrategy {
     /// The foreground colors are the inverse of the component background colors.
     pub const ARKUI_COLOR_STRATEGY_INVERT: ArkUI_ColorStrategy = ArkUI_ColorStrategy(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ColorStrategy {
     /// The shadow colors of the component are the average color obtained from the component background shadow area.
     pub const ARKUI_COLOR_STRATEGY_AVERAGE: ArkUI_ColorStrategy = ArkUI_ColorStrategy(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ColorStrategy {
     /// The shadow colors of the component are the primary color obtained from the component background shadow area.
     pub const ARKUI_COLOR_STRATEGY_PRIMARY: ArkUI_ColorStrategy = ArkUI_ColorStrategy(2);
 }
@@ -2435,38 +1559,18 @@ pub struct ArkUI_ColorStrategy(pub ::core::ffi::c_uint);
 impl ArkUI_FlexAlignment {
     /// The child components are aligned with the start edge of the main axis.
     pub const ARKUI_FLEX_ALIGNMENT_START: ArkUI_FlexAlignment = ArkUI_FlexAlignment(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FlexAlignment {
     /// The child components are aligned in the center of the main axis.
     pub const ARKUI_FLEX_ALIGNMENT_CENTER: ArkUI_FlexAlignment = ArkUI_FlexAlignment(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FlexAlignment {
     /// The child components are aligned with the end edge of the main axis.
     pub const ARKUI_FLEX_ALIGNMENT_END: ArkUI_FlexAlignment = ArkUI_FlexAlignment(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FlexAlignment {
     /// The child components are evenly distributed along the main axis. The space between any two adjacent components
     /// is the same. The first component is aligned with the main-start, and the last component is aligned with
     /// the main-end.
     pub const ARKUI_FLEX_ALIGNMENT_SPACE_BETWEEN: ArkUI_FlexAlignment = ArkUI_FlexAlignment(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FlexAlignment {
     /// The child components are evenly distributed along the main axis. The space between any two adjacent components
     /// is the same. The space between the first component and main-start, and that between the last component and
     /// cross-main are both half the size of the space between two adjacent components.
     pub const ARKUI_FLEX_ALIGNMENT_SPACE_AROUND: ArkUI_FlexAlignment = ArkUI_FlexAlignment(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FlexAlignment {
     /// The child components are evenly distributed along the main axis. The space between the first component
     /// and main-start, the space between the last component and main-end, and the space between any two adjacent
     /// components are the same.
@@ -2486,22 +1590,10 @@ pub struct ArkUI_FlexAlignment(pub ::core::ffi::c_uint);
 impl ArkUI_FlexDirection {
     /// The child components are arranged in the same direction as the main axis runs along the rows.
     pub const ARKUI_FLEX_DIRECTION_ROW: ArkUI_FlexDirection = ArkUI_FlexDirection(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FlexDirection {
     /// The child components are arranged in the same direction as the main axis runs down the columns.
     pub const ARKUI_FLEX_DIRECTION_COLUMN: ArkUI_FlexDirection = ArkUI_FlexDirection(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FlexDirection {
     /// The child components are arranged opposite to the <b>ROW</b> direction.
     pub const ARKUI_FLEX_DIRECTION_ROW_REVERSE: ArkUI_FlexDirection = ArkUI_FlexDirection(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FlexDirection {
     /// The child components are arranged opposite to the <b>COLUMN</b> direction.
     pub const ARKUI_FLEX_DIRECTION_COLUMN_REVERSE: ArkUI_FlexDirection = ArkUI_FlexDirection(3);
 }
@@ -2519,16 +1611,8 @@ pub struct ArkUI_FlexDirection(pub ::core::ffi::c_uint);
 impl ArkUI_FlexWrap {
     /// The child components in the flex container are arranged in a single line, and they cannot overflow.
     pub const ARKUI_FLEX_WRAP_NO_WRAP: ArkUI_FlexWrap = ArkUI_FlexWrap(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FlexWrap {
     /// The child components in the flex container are arranged in multiple lines, and they may overflow.
     pub const ARKUI_FLEX_WRAP_WRAP: ArkUI_FlexWrap = ArkUI_FlexWrap(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FlexWrap {
     /// The child components in the flex container are reversely arranged in multiple lines, and they may overflow.
     pub const ARKUI_FLEX_WRAP_WRAP_REVERSE: ArkUI_FlexWrap = ArkUI_FlexWrap(2);
 }
@@ -2546,16 +1630,8 @@ pub struct ArkUI_FlexWrap(pub ::core::ffi::c_uint);
 impl ArkUI_Visibility {
     /// The component is visible.
     pub const ARKUI_VISIBILITY_VISIBLE: ArkUI_Visibility = ArkUI_Visibility(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Visibility {
     /// The component is hidden, and a placeholder is used for it in the layout.
     pub const ARKUI_VISIBILITY_HIDDEN: ArkUI_Visibility = ArkUI_Visibility(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_Visibility {
     /// The component is hidden. It is not involved in the layout, and no placeholder is used for it.
     pub const ARKUI_VISIBILITY_NONE: ArkUI_Visibility = ArkUI_Visibility(2);
 }
@@ -2573,16 +1649,8 @@ pub struct ArkUI_Visibility(pub ::core::ffi::c_uint);
 impl ArkUI_CalendarAlignment {
     /// Left aligned.
     pub const ARKUI_CALENDAR_ALIGNMENT_START: ArkUI_CalendarAlignment = ArkUI_CalendarAlignment(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_CalendarAlignment {
     /// Center aligned.
     pub const ARKUI_CALENDAR_ALIGNMENT_CENTER: ArkUI_CalendarAlignment = ArkUI_CalendarAlignment(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_CalendarAlignment {
     /// Right aligned.
     pub const ARKUI_CALENDAR_ALIGNMENT_END: ArkUI_CalendarAlignment = ArkUI_CalendarAlignment(2);
 }
@@ -2600,28 +1668,12 @@ pub struct ArkUI_CalendarAlignment(pub ::core::ffi::c_uint);
 impl ArkUI_MaskType {
     /// Rectangle.
     pub const ARKUI_MASK_TYPE_RECTANGLE: ArkUI_MaskType = ArkUI_MaskType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_MaskType {
     /// Circle.
     pub const ARKUI_MASK_TYPE_CIRCLE: ArkUI_MaskType = ArkUI_MaskType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_MaskType {
     /// Ellipse.
     pub const ARKUI_MASK_TYPE_ELLIPSE: ArkUI_MaskType = ArkUI_MaskType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_MaskType {
     /// Path.
     pub const ARKUI_MASK_TYPE_PATH: ArkUI_MaskType = ArkUI_MaskType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_MaskType {
     /// Progress indicator.
     pub const ARKUI_MASK_TYPE_PROGRESS: ArkUI_MaskType = ArkUI_MaskType(4);
 }
@@ -2639,22 +1691,10 @@ pub struct ArkUI_MaskType(pub ::core::ffi::c_uint);
 impl ArkUI_ClipType {
     /// Rectangle.
     pub const ARKUI_CLIP_TYPE_RECTANGLE: ArkUI_ClipType = ArkUI_ClipType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ClipType {
     /// Circle.
     pub const ARKUI_CLIP_TYPE_CIRCLE: ArkUI_ClipType = ArkUI_ClipType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ClipType {
     /// Ellipse.
     pub const ARKUI_CLIP_TYPE_ELLIPSE: ArkUI_ClipType = ArkUI_ClipType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ClipType {
     /// Path.
     pub const ARKUI_CLIP_TYPE_PATH: ArkUI_ClipType = ArkUI_ClipType(3);
 }
@@ -2688,22 +1728,10 @@ pub struct ArkUI_ColorStop {
 impl ArkUI_ShapeType {
     /// Rectangle.
     pub const ARKUI_SHAPE_TYPE_RECTANGLE: ArkUI_ShapeType = ArkUI_ShapeType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ShapeType {
     /// Circle.
     pub const ARKUI_SHAPE_TYPE_CIRCLE: ArkUI_ShapeType = ArkUI_ShapeType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ShapeType {
     /// Ellipse.
     pub const ARKUI_SHAPE_TYPE_ELLIPSE: ArkUI_ShapeType = ArkUI_ShapeType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ShapeType {
     /// Path.
     pub const ARKUI_SHAPE_TYPE_PATH: ArkUI_ShapeType = ArkUI_ShapeType(3);
 }
@@ -2722,66 +1750,30 @@ impl ArkUI_LinearGradientDirection {
     /// From right to left.
     pub const ARKUI_LINEAR_GRADIENT_DIRECTION_LEFT: ArkUI_LinearGradientDirection =
         ArkUI_LinearGradientDirection(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LinearGradientDirection {
     /// From bottom to top.
     pub const ARKUI_LINEAR_GRADIENT_DIRECTION_TOP: ArkUI_LinearGradientDirection =
         ArkUI_LinearGradientDirection(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LinearGradientDirection {
     /// From left to right.
     pub const ARKUI_LINEAR_GRADIENT_DIRECTION_RIGHT: ArkUI_LinearGradientDirection =
         ArkUI_LinearGradientDirection(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LinearGradientDirection {
     /// From top to bottom.
     pub const ARKUI_LINEAR_GRADIENT_DIRECTION_BOTTOM: ArkUI_LinearGradientDirection =
         ArkUI_LinearGradientDirection(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LinearGradientDirection {
     /// From lower right to upper left.
     pub const ARKUI_LINEAR_GRADIENT_DIRECTION_LEFT_TOP: ArkUI_LinearGradientDirection =
         ArkUI_LinearGradientDirection(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LinearGradientDirection {
     /// From upper right to lower left.
     pub const ARKUI_LINEAR_GRADIENT_DIRECTION_LEFT_BOTTOM: ArkUI_LinearGradientDirection =
         ArkUI_LinearGradientDirection(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LinearGradientDirection {
     /// From lower left to upper right.
     pub const ARKUI_LINEAR_GRADIENT_DIRECTION_RIGHT_TOP: ArkUI_LinearGradientDirection =
         ArkUI_LinearGradientDirection(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LinearGradientDirection {
     /// From upper left to lower right.
     pub const ARKUI_LINEAR_GRADIENT_DIRECTION_RIGHT_BOTTOM: ArkUI_LinearGradientDirection =
         ArkUI_LinearGradientDirection(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LinearGradientDirection {
     /// No gradient.
     pub const ARKUI_LINEAR_GRADIENT_DIRECTION_NONE: ArkUI_LinearGradientDirection =
         ArkUI_LinearGradientDirection(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LinearGradientDirection {
     /// Custom direction.
     pub const ARKUI_LINEAR_GRADIENT_DIRECTION_CUSTOM: ArkUI_LinearGradientDirection =
         ArkUI_LinearGradientDirection(9);
@@ -2801,17 +1793,9 @@ impl ArkUI_WordBreak {
     /// Word breaks can occur between any two characters for Chinese, Japanese, and Korean (CJK) text, but can occur
     /// only at a space character for non-CJK text (such as English).
     pub const ARKUI_WORD_BREAK_NORMAL: ArkUI_WordBreak = ArkUI_WordBreak(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_WordBreak {
     /// Word breaks can occur between any two characters for non-CJK text. CJK text behavior is the same as for
     /// <b>NORMAL</b>.
     pub const ARKUI_WORD_BREAK_BREAK_ALL: ArkUI_WordBreak = ArkUI_WordBreak(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_WordBreak {
     /// This option has the same effect as <b>BREAK_ALL</b> for non-CJK text, except that if it preferentially wraps
     /// lines at appropriate characters (for example, spaces) whenever possible.
     /// CJK text behavior is the same as for <b>NORMAL</b>.
@@ -2831,16 +1815,8 @@ pub struct ArkUI_WordBreak(pub ::core::ffi::c_uint);
 impl ArkUI_EllipsisMode {
     /// An ellipsis is used at the start of the line of text.
     pub const ARKUI_ELLIPSIS_MODE_START: ArkUI_EllipsisMode = ArkUI_EllipsisMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_EllipsisMode {
     /// An ellipsis is used at the center of the line of text.
     pub const ARKUI_ELLIPSIS_MODE_CENTER: ArkUI_EllipsisMode = ArkUI_EllipsisMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_EllipsisMode {
     /// An ellipsis is used at the end of the line of text.
     pub const ARKUI_ELLIPSIS_MODE_END: ArkUI_EllipsisMode = ArkUI_EllipsisMode(2);
 }
@@ -2858,10 +1834,6 @@ pub struct ArkUI_EllipsisMode(pub ::core::ffi::c_uint);
 impl ArkUI_ImageRenderMode {
     /// Render image pixels as they are in the original source image.
     pub const ARKUI_IMAGE_RENDER_MODE_ORIGINAL: ArkUI_ImageRenderMode = ArkUI_ImageRenderMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ImageRenderMode {
     /// Render image pixels to create a monochrome template image.
     pub const ARKUI_IMAGE_RENDER_MODE_TEMPLATE: ArkUI_ImageRenderMode = ArkUI_ImageRenderMode(1);
 }
@@ -2879,22 +1851,10 @@ pub struct ArkUI_ImageRenderMode(pub ::core::ffi::c_uint);
 impl ArkUI_TransitionEdge {
     /// Top edge of the window.
     pub const ARKUI_TRANSITION_EDGE_TOP: ArkUI_TransitionEdge = ArkUI_TransitionEdge(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TransitionEdge {
     /// Bottom edge of the window.
     pub const ARKUI_TRANSITION_EDGE_BOTTOM: ArkUI_TransitionEdge = ArkUI_TransitionEdge(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TransitionEdge {
     /// Left edge of the window.
     pub const ARKUI_TRANSITION_EDGE_START: ArkUI_TransitionEdge = ArkUI_TransitionEdge(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TransitionEdge {
     /// Right edge of the window.
     pub const ARKUI_TRANSITION_EDGE_END: ArkUI_TransitionEdge = ArkUI_TransitionEdge(3);
 }
@@ -2912,10 +1872,6 @@ pub struct ArkUI_TransitionEdge(pub ::core::ffi::c_uint);
 impl ArkUI_BlendApplyType {
     /// The content of the view is blended in sequence on the target image.
     pub const BLEND_APPLY_TYPE_FAST: ArkUI_BlendApplyType = ArkUI_BlendApplyType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BlendApplyType {
     /// The content of the component and its child components are drawn on the offscreen canvas, and then blended with
     /// the existing content on the canvas.
     pub const BLEND_APPLY_TYPE_OFFSCREEN: ArkUI_BlendApplyType = ArkUI_BlendApplyType(1);
@@ -2980,10 +1936,6 @@ pub struct ArkUI_IntOffset {
 impl ArkUI_FinishCallbackType {
     /// The callback is invoked when the entire animation is removed once it has finished.
     pub const ARKUI_FINISH_CALLBACK_REMOVED: ArkUI_FinishCallbackType = ArkUI_FinishCallbackType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_FinishCallbackType {
     /// The callback is invoked when the animation logically enters the falling state, though it may still be in its
     /// long tail state.
     pub const ARKUI_FINISH_CALLBACK_LOGICALLY: ArkUI_FinishCallbackType =
@@ -3003,17 +1955,9 @@ pub struct ArkUI_FinishCallbackType(pub ::core::ffi::c_uint);
 impl ArkUI_ListItemAlignment {
     /// The list items are packed toward the start edge of the list container along the cross axis.
     pub const ARKUI_LIST_ITEM_ALIGNMENT_START: ArkUI_ListItemAlignment = ArkUI_ListItemAlignment(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ListItemAlignment {
     /// The list items are centered in the list container along the cross axis.
     pub const ARKUI_LIST_ITEM_ALIGNMENT_CENTER: ArkUI_ListItemAlignment =
         ArkUI_ListItemAlignment(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ListItemAlignment {
     /// The list items are packed toward the end edge of the list container along the cross axis.
     pub const ARKUI_LIST_ITEM_ALIGNMENT_END: ArkUI_ListItemAlignment = ArkUI_ListItemAlignment(2);
 }
@@ -3031,22 +1975,10 @@ pub struct ArkUI_ListItemAlignment(pub ::core::ffi::c_uint);
 impl ArkUI_BarrierDirection {
     /// The barrier is the leftmost of all its referencedIds.
     pub const ARKUI_BARRIER_DIRECTION_START: ArkUI_BarrierDirection = ArkUI_BarrierDirection(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BarrierDirection {
     /// The barrier is on the rightmost side of all its referencedIds.
     pub const ARKUI_BARRIER_DIRECTION_END: ArkUI_BarrierDirection = ArkUI_BarrierDirection(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BarrierDirection {
     /// The barrier is at the top of all its referencedIds.
     pub const ARKUI_BARRIER_DIRECTION_TOP: ArkUI_BarrierDirection = ArkUI_BarrierDirection(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_BarrierDirection {
     /// The barrier is at the bottom of all its referencedIds.
     pub const ARKUI_BARRIER_DIRECTION_BOTTOM: ArkUI_BarrierDirection = ArkUI_BarrierDirection(3);
 }
@@ -3065,18 +1997,10 @@ impl ArkUI_RelativeLayoutChainStyle {
     /// Components are evenly distributed among constraint anchor points.
     pub const ARKUI_RELATIVE_LAYOUT_CHAIN_STYLE_SPREAD: ArkUI_RelativeLayoutChainStyle =
         ArkUI_RelativeLayoutChainStyle(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RelativeLayoutChainStyle {
     /// Except for the first and last two sub-components,
     /// other components are evenly distributed between the constraint anchor points.
     pub const ARKUI_RELATIVE_LAYOUT_CHAIN_STYLE_SPREAD_INSIDE: ArkUI_RelativeLayoutChainStyle =
         ArkUI_RelativeLayoutChainStyle(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RelativeLayoutChainStyle {
     /// No gaps in subcomponents within the chain.
     pub const ARKUI_RELATIVE_LAYOUT_CHAIN_STYLE_PACKED: ArkUI_RelativeLayoutChainStyle =
         ArkUI_RelativeLayoutChainStyle(2);
@@ -3113,22 +2037,10 @@ pub struct ArkUI_Margin {
 impl ArkUI_LengthMetricUnit {
     /// Default, which is fp for fonts and vp for non-fonts.
     pub const ARKUI_LENGTH_METRIC_UNIT_DEFAULT: ArkUI_LengthMetricUnit = ArkUI_LengthMetricUnit(-1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LengthMetricUnit {
     /// px.
     pub const ARKUI_LENGTH_METRIC_UNIT_PX: ArkUI_LengthMetricUnit = ArkUI_LengthMetricUnit(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LengthMetricUnit {
     /// vp.
     pub const ARKUI_LENGTH_METRIC_UNIT_VP: ArkUI_LengthMetricUnit = ArkUI_LengthMetricUnit(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_LengthMetricUnit {
     /// fp.
     pub const ARKUI_LENGTH_METRIC_UNIT_FP: ArkUI_LengthMetricUnit = ArkUI_LengthMetricUnit(2);
 }
@@ -3147,81 +2059,37 @@ impl ArkUI_RenderFit {
     /// Maintains the content size of the animation's final state,
     /// and the content is always centered with the component.
     pub const ARKUI_RENDER_FIT_CENTER: ArkUI_RenderFit = ArkUI_RenderFit(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Maintains the content size of the animation's final state,
     /// and the content is always aligned with the top center of the component.
     pub const ARKUI_RENDER_FIT_TOP: ArkUI_RenderFit = ArkUI_RenderFit(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Maintains the content size of the animation's final state,
     /// and the content is always aligned with the bottom center of the component.
     pub const ARKUI_RENDER_FIT_BOTTOM: ArkUI_RenderFit = ArkUI_RenderFit(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Maintains the content size of the animation's final state,
     /// and the content is always aligned to the left of the component.
     pub const ARKUI_RENDER_FIT_LEFT: ArkUI_RenderFit = ArkUI_RenderFit(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Maintains the content size of the animation's final state,
     /// and the content is always right-aligned with the component.
     pub const ARKUI_RENDER_FIT_RIGHT: ArkUI_RenderFit = ArkUI_RenderFit(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Maintains the content size of the animation's final state,
     /// and the content is always aligned with the top left corner of the component.
     pub const ARKUI_RENDER_FIT_TOP_LEFT: ArkUI_RenderFit = ArkUI_RenderFit(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Keep the content size of the animation final state,
     /// and the content is always aligned with the upper right corner of the component.
     pub const ARKUI_RENDER_FIT_TOP_RIGHT: ArkUI_RenderFit = ArkUI_RenderFit(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Keep the content size of the animation final state,
     /// and the content always aligns with the lower-left corner of the component.
     pub const ARKUI_RENDER_FIT_BOTTOM_LEFT: ArkUI_RenderFit = ArkUI_RenderFit(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Keep the content size of the animation final state,
     /// and the content always aligns with the lower-right corner of the component.
     pub const ARKUI_RENDER_FIT_BOTTOM_RIGHT: ArkUI_RenderFit = ArkUI_RenderFit(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// The aspect ratio of the animation's final state content is not considered,
     /// and the content is always scaled to the size of the component.
     pub const ARKUI_RENDER_FIT_RESIZE_FILL: ArkUI_RenderFit = ArkUI_RenderFit(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Reduce or enlarge the aspect ratio of the animation final state content,
     /// so that the content is fully displayed in the component,
     /// and keep the center aligned with the component.
     pub const ARKUI_RENDER_FIT_RESIZE_CONTAIN: ArkUI_RenderFit = ArkUI_RenderFit(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Keep the aspect ratio of the animation final state content to reduce or enlarge,
     /// so that the content is fully displayed in the component.
     /// When there is left over in the broad direction of the component,
@@ -3229,10 +2097,6 @@ impl ArkUI_RenderFit {
     /// and when there is left over in the high direction of the component,
     /// the content is aligned to the top of the component.
     pub const ARKUI_RENDER_FIT_RESIZE_CONTAIN_TOP_LEFT: ArkUI_RenderFit = ArkUI_RenderFit(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Keep the aspect ratio of the animation final state content to reduce or enlarge,
     /// so that the content is fully displayed in the component.
     /// When there is left in the wide direction of the component,
@@ -3240,28 +2104,16 @@ impl ArkUI_RenderFit {
     /// When there is left in the high direction of the component,
     /// the content is aligned with the component on the bottom.
     pub const ARKUI_RENDER_FIT_RESIZE_CONTAIN_BOTTOM_RIGHT: ArkUI_RenderFit = ArkUI_RenderFit(12);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Keep the aspect ratio of the animation final state content reduced or enlarged,
     /// so that both sides of the content are greater than or equal to both sides of the component,
     /// and keep the center aligned with the component to display the middle part of the content.
     pub const ARKUI_RENDER_FIT_RESIZE_COVER: ArkUI_RenderFit = ArkUI_RenderFit(13);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Keep the aspect ratio of the final content of the animation reduced or enlarged
     /// so that both sides of the content are exactly greater than or equal to both sides of the component.
     /// When the content width is left, the content is aligned to the left of the component,
     /// and the left portion of the content is displayed. When the content is left in the high direction,
     /// the content and the component remain top aligned, showing the top side of the content.
     pub const ARKUI_RENDER_FIT_RESIZE_COVER_TOP_LEFT: ArkUI_RenderFit = ArkUI_RenderFit(14);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RenderFit {
     /// Keep the aspect ratio of the final content of the animation reduced or enlarged so
     /// that both sides of the content are exactly greater than or equal to both sides of the component.
     /// When the content width is left, the content and the component remain right aligned,
@@ -3284,16 +2136,8 @@ pub struct ArkUI_RenderFit(pub ::core::ffi::c_uint);
 impl ArkUI_ButtonType {
     /// Normal button (without rounded corners by default).
     pub const ARKUI_BUTTON_TYPE_NORMAL: ArkUI_ButtonType = ArkUI_ButtonType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ButtonType {
     /// Capsule-type button (the round corner is half of the height by default).
     pub const ARKUI_BUTTON_TYPE_CAPSULE: ArkUI_ButtonType = ArkUI_ButtonType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ButtonType {
     /// Circle button.
     pub const ARKUI_BUTTON_TYPE_CIRCLE: ArkUI_ButtonType = ArkUI_ButtonType(2);
 }
@@ -3312,153 +2156,73 @@ impl ArkUI_TextInputContentType {
     /// Username. Password Vault, when enabled, can automatically save and fill in usernames.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_USER_NAME: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Password. Password Vault, when enabled, can automatically save and fill in passwords.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_PASSWORD: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// New password. Password Vault, when enabled, can automatically generate a new password.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_NEW_PASSWORD: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Full street address. The scenario-based autofill feature, when enabled, can automatically save and fill in full
     /// street addresses.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_FULL_STREET_ADDRESS: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// House number. The scenario-based autofill feature, when enabled, can automatically save and fill in house
     /// numbers.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_HOUSE_NUMBER: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// District and county. The scenario-based autofill feature, when enabled, can automatically save and fill in
     /// districts and counties.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_DISTRICT_ADDRESS: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// City. The scenario-based autofill feature, when enabled, can automatically save and fill in cities.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_CITY_ADDRESS: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Province. The scenario-based autofill feature, when enabled, can automatically save and fill in provinces.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_PROVINCE_ADDRESS: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Country. The scenario-based autofill feature, when enabled, can automatically save and fill in countries.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_COUNTRY_ADDRESS: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Full name. The scenario-based autofill feature, when enabled, can automatically save and fill in full names.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_PERSON_FULL_NAME: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Last name. The scenario-based autofill feature, when enabled, can automatically save and fill in last names.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_PERSON_LAST_NAME: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// First name. The scenario-based autofill feature, when enabled, can automatically save and fill in first names.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_PERSON_FIRST_NAME: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Phone number. The scenario-based autofill feature, when enabled, can automatically save and fill in phone
     /// numbers.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_PHONE_NUMBER: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(12);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Country code. The scenario-based autofill feature, when enabled, can automatically save and fill in country
     /// codes.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_PHONE_COUNTRY_CODE: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(13);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Phone number with country code. The scenario-based autofill feature, when enabled, can automatically save and
     /// fill in phone numbers with country codes.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_FULL_PHONE_NUMBER: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(14);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Email address. The scenario-based autofill feature, when enabled, can automatically save and fill in email
     /// addresses.
     pub const ARKUI_TEXTINPUT_CONTENT_EMAIL_ADDRESS: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(15);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Bank card number. The scenario-based autofill feature, when enabled, can automatically save and fill in bank
     /// card numbers.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_BANK_CARD_NUMBER: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(16);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// ID card number. The scenario-based autofill feature, when enabled, can automatically save and fill in ID card
     /// numbers.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_ID_CARD_NUMBER: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(17);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Nickname. The scenario-based autofill feature, when enabled, can automatically save and fill in nicknames.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_NICKNAME: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(18);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Address information without street address. The scenario-based autofill feature, when enabled, can automatically
     /// save and fill in address information without street addresses.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_DETAIL_INFO_WITHOUT_STREET: ArkUI_TextInputContentType =
         ArkUI_TextInputContentType(19);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputContentType {
     /// Standard address. The scenario-based autofill feature, when enabled, can automatically save and fill in standard
     /// addresses.
     pub const ARKUI_TEXTINPUT_CONTENT_TYPE_FORMAT_ADDRESS: ArkUI_TextInputContentType =
@@ -3479,10 +2243,6 @@ impl ArkUI_TextInputStyle {
     /// Default style. The caret width is fixed at 1.5 vp, and the caret height is subject to the background height and
     /// font size of the selected text.
     pub const ARKUI_TEXTINPUT_STYLE_DEFAULT: ArkUI_TextInputStyle = ArkUI_TextInputStyle(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextInputStyle {
     /// Inline input style. The background height of the selected text is the same as the height of the text box.
     pub const ARKUI_TEXTINPUT_STYLE_INLINE: ArkUI_TextInputStyle = ArkUI_TextInputStyle(1);
 }
@@ -3501,24 +2261,12 @@ impl ArkUI_TextDataDetectorType {
     /// Phone Number.
     pub const ARKUI_TEXT_DATA_DETECTOR_TYPE_PHONE_NUMBER: ArkUI_TextDataDetectorType =
         ArkUI_TextDataDetectorType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextDataDetectorType {
     /// Link.
     pub const ARKUI_TEXT_DATA_DETECTOR_TYPE_URL: ArkUI_TextDataDetectorType =
         ArkUI_TextDataDetectorType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextDataDetectorType {
     /// Mailbox.
     pub const ARKUI_TEXT_DATA_DETECTOR_TYPE_EMAIL: ArkUI_TextDataDetectorType =
         ArkUI_TextDataDetectorType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_TextDataDetectorType {
     /// Address.
     pub const ARKUI_TEXT_DATA_DETECTOR_TYPE_ADDRESS: ArkUI_TextDataDetectorType =
         ArkUI_TextDataDetectorType(3);
@@ -3538,10 +2286,6 @@ impl ArkUI_SwiperIndicatorType {
     /// dot type.
     pub const ARKUI_SWIPER_INDICATOR_TYPE_DOT: ArkUI_SwiperIndicatorType =
         ArkUI_SwiperIndicatorType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SwiperIndicatorType {
     /// digit type.
     pub const ARKUI_SWIPER_INDICATOR_TYPE_DIGIT: ArkUI_SwiperIndicatorType =
         ArkUI_SwiperIndicatorType(1);
@@ -3562,18 +2306,10 @@ impl ArkUI_ListItemSwipeActionState {
     /// the operation item is hidden.
     pub const ARKUI_LIST_ITEM_SWIPE_ACTION_STATE_COLLAPSED: ArkUI_ListItemSwipeActionState =
         ArkUI_ListItemSwipeActionState(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ListItemSwipeActionState {
     /// In the folded state, when the ListItem slides in the opposite direction to the spindle,
     /// the operation item is displayed.
     pub const ARKUI_LIST_ITEM_SWIPE_ACTION_STATE_EXPANDED: ArkUI_ListItemSwipeActionState =
         ArkUI_ListItemSwipeActionState(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ListItemSwipeActionState {
     /// Long distance state, the state of deleting a ListItem after it enters the long distance deletion area.
     pub const ARKUI_LIST_ITEM_SWIPE_ACTION_STATE_ACTIONING: ArkUI_ListItemSwipeActionState =
         ArkUI_ListItemSwipeActionState(2);
@@ -3593,10 +2329,6 @@ impl ArkUI_ListItemSwipeEdgeEffect {
     /// The ListItem can continue to be scratched after the distance exceeds the size of the scratched component.
     pub const ARKUI_LIST_ITEM_SWIPE_EDGE_EFFECT_SPRING: ArkUI_ListItemSwipeEdgeEffect =
         ArkUI_ListItemSwipeEdgeEffect(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ListItemSwipeEdgeEffect {
     /// The sliding distance of the ListItem cannot exceed the size of the scratched component.
     pub const ARKUI_LIST_ITEM_SWIPE_EDGE_EFFECT_NONE: ArkUI_ListItemSwipeEdgeEffect =
         ArkUI_ListItemSwipeEdgeEffect(1);
@@ -3610,107 +2342,52 @@ impl ArkUI_ListItemSwipeEdgeEffect {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ArkUI_ListItemSwipeEdgeEffect(pub ::core::ffi::c_uint);
+pub type ArkUiResult = Result<(), ArkUiErrorCode>;
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl ArkUiErrorCode {
     /// Parameter error.
     pub const PARAM_INVALID: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(401).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The component does not support specific properties or events.
     pub const ATTRIBUTE_OR_EVENT_NOT_SUPPORTED: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(106102).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The corresponding operation does not support nodes created by ArkTS.
     pub const ARKTS_NODE_NOT_SUPPORTED: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(106103).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The lazy loading adapter is not bound to the component.
     pub const ADAPTER_NOT_BOUND: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(106104).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The adapter already exists.
     pub const ADAPTER_EXIST: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(106105).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The corresponding node already has a child node and cannot add an adapter.
     pub const CHILD_NODE_EXIST: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(106106).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The parameter length in the parameter event exceeds the limit.
     pub const NODE_EVENT_PARAM_INDEX_OUT_OF_RANGE: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(106107).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The data does not exist in the component event.
     pub const NODE_EVENT_PARAM_INVALID: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(106108).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The component event does not support return values.
     pub const NODE_EVENT_NO_RETURN: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(106109).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The index value is invalid.
     pub const NODE_INDEX_INVALID: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(106200).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// Failed to query route navigation information.
     pub const GET_INFO_FAILED: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(106201).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The buffer size is not large enough.
     pub const BUFFER_SIZE_ERROR: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(106202).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The component is not a scroll container.
     pub const NON_SCROLLABLE_CONTAINER: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(180001).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// The buffer is not large enough.
     pub const BUFFER_SIZE_NOT_ENOUGH: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(180002).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUiErrorCode {
     /// invalid styled string.
     ///
     /// Available since API-level: 14
@@ -3719,7 +2396,6 @@ impl ArkUiErrorCode {
     pub const INVALID_STYLED_STRING: ArkUiErrorCode =
         ArkUiErrorCode(const { core::num::NonZero::new(180101).unwrap() });
 }
-pub type ArkUiResult = Result<(), ArkUiErrorCode>;
 #[repr(transparent)]
 /// Define error code enumeration values.
 ///
@@ -3734,22 +2410,10 @@ pub struct ArkUiErrorCode(pub core::num::NonZero<::core::ffi::c_uint>);
 impl ArkUI_AnimationStatus {
     /// The animation is in the initial state.
     pub const ARKUI_ANIMATION_STATUS_INITIAL: ArkUI_AnimationStatus = ArkUI_AnimationStatus(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationStatus {
     /// The animation is being played.
     pub const ARKUI_ANIMATION_STATUS_RUNNING: ArkUI_AnimationStatus = ArkUI_AnimationStatus(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationStatus {
     /// The animation is paused.
     pub const ARKUI_ANIMATION_STATUS_PAUSED: ArkUI_AnimationStatus = ArkUI_AnimationStatus(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationStatus {
     /// The animation is stopped.
     pub const ARKUI_ANIMATION_STATUS_STOPPED: ArkUI_AnimationStatus = ArkUI_AnimationStatus(3);
 }
@@ -3768,26 +2432,14 @@ impl ArkUI_AnimationFillMode {
     /// Before execution, the animation does not apply any styles to the target component.
     /// After execution, the animation restores the target component to its default state.
     pub const ARKUI_ANIMATION_FILL_MODE_NONE: ArkUI_AnimationFillMode = ArkUI_AnimationFillMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationFillMode {
     /// The target component retains the state set by the last keyframe encountered
     /// during execution of the animation.
     pub const ARKUI_ANIMATION_FILL_MODE_FORWARDS: ArkUI_AnimationFillMode =
         ArkUI_AnimationFillMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationFillMode {
     /// The animation applies the values defined in the first relevant keyframe once it is applied to
     /// the target component, and retains the values during the period set by delay.
     pub const ARKUI_ANIMATION_FILL_MODE_BACKWARDS: ArkUI_AnimationFillMode =
         ArkUI_AnimationFillMode(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationFillMode {
     /// The animation follows the rules for both Forwards and Backwards,
     /// extending the animation attributes in both directions.
     pub const ARKUI_ANIMATION_FILL_MODE_BOTH: ArkUI_AnimationFillMode = ArkUI_AnimationFillMode(3);
@@ -3807,10 +2459,6 @@ impl ArkUI_AccessibilityCheckedState {
     /// The Checkbox unchecked.
     pub const ARKUI_ACCESSIBILITY_UNCHECKED: ArkUI_AccessibilityCheckedState =
         ArkUI_AccessibilityCheckedState(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AccessibilityCheckedState {
     /// The Checkbox checked.
     pub const ARKUI_ACCESSIBILITY_CHECKED: ArkUI_AccessibilityCheckedState =
         ArkUI_AccessibilityCheckedState(1);
@@ -3830,26 +2478,14 @@ impl ArkUI_AnimationDirection {
     /// The animation plays in forward loop mode.
     pub const ARKUI_ANIMATION_DIRECTION_NORMAL: ArkUI_AnimationDirection =
         ArkUI_AnimationDirection(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationDirection {
     /// The animation plays in reverse loop mode.
     pub const ARKUI_ANIMATION_DIRECTION_REVERSE: ArkUI_AnimationDirection =
         ArkUI_AnimationDirection(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationDirection {
     /// The animation plays in alternating loop mode. When the animation is played for an odd number of times, the
     /// playback is in forward direction. When the animation is played for an even number of times, the playback is in
     /// reverse direction.
     pub const ARKUI_ANIMATION_DIRECTION_ALTERNATE: ArkUI_AnimationDirection =
         ArkUI_AnimationDirection(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AnimationDirection {
     /// The animation plays in reverse alternating loop mode. When the animation is played for an odd number of times,
     /// the playback is in reverse direction. When the animation is played for an even number of times, the playback is
     /// in forward direction.
@@ -3870,46 +2506,18 @@ pub struct ArkUI_AnimationDirection(pub ::core::ffi::c_uint);
 impl ArkUI_ScrollSource {
     /// Finger drag.
     pub const ARKUI_SCROLL_SOURCE_DRAG: ArkUI_ScrollSource = ArkUI_ScrollSource(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollSource {
     /// Inertial roll after finger drag.
     pub const ARKUI_SCROLL_SOURCE_FLING: ArkUI_ScrollSource = ArkUI_ScrollSource(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollSource {
     /// Execute the EdgeEffect.Spring edge effect when crossing the boundary.
     pub const ARKUI_SCROLL_SOURCE_EDGE_EFFECT: ArkUI_ScrollSource = ArkUI_ScrollSource(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollSource {
     /// Other user input other than dragging, such as mouse wheel, keyboard events, etc.
     pub const ARKUI_SCROLL_SOURCE_OTHER_USER_INPUT: ArkUI_ScrollSource = ArkUI_ScrollSource(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollSource {
     /// Drag the scroll bar.
     pub const ARKUI_SCROLL_SOURCE_SCROLL_BAR: ArkUI_ScrollSource = ArkUI_ScrollSource(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollSource {
     /// Inertia scrolling after dragging the scroll bar.
     pub const ARKUI_SCROLL_SOURCE_SCROLL_BAR_FLING: ArkUI_ScrollSource = ArkUI_ScrollSource(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollSource {
     /// The scroll controller causes unanimated scrolling.
     pub const ARKUI_SCROLL_SOURCE_SCROLLER: ArkUI_ScrollSource = ArkUI_ScrollSource(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ScrollSource {
     /// The scroll controller causes the scroll to drive the painting.
     pub const ARKUI_SCROLL_SOURCE_ANIMATION: ArkUI_ScrollSource = ArkUI_ScrollSource(7);
 }
@@ -3928,31 +2536,15 @@ impl ArkUI_AccessibilityActionType {
     /// click action.
     pub const ARKUI_ACCESSIBILITY_ACTION_CLICK: ArkUI_AccessibilityActionType =
         ArkUI_AccessibilityActionType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AccessibilityActionType {
     /// long click action.
     pub const ARKUI_ACCESSIBILITY_ACTION_LONG_CLICK: ArkUI_AccessibilityActionType =
         ArkUI_AccessibilityActionType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AccessibilityActionType {
     /// cut action.
     pub const ARKUI_ACCESSIBILITY_ACTION_CUT: ArkUI_AccessibilityActionType =
         ArkUI_AccessibilityActionType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AccessibilityActionType {
     /// copy action.
     pub const ARKUI_ACCESSIBILITY_ACTION_COPY: ArkUI_AccessibilityActionType =
         ArkUI_AccessibilityActionType(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_AccessibilityActionType {
     /// paste action.
     pub const ARKUI_ACCESSIBILITY_ACTION_PASTE: ArkUI_AccessibilityActionType =
         ArkUI_AccessibilityActionType(16);
@@ -4046,59 +2638,27 @@ impl ArkUI_NavDestinationState {
     /// The NavDestination show.
     pub const ARKUI_NAV_DESTINATION_STATE_ON_SHOW: ArkUI_NavDestinationState =
         ArkUI_NavDestinationState(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NavDestinationState {
     /// The NavDestination hide.
     pub const ARKUI_NAV_DESTINATION_STATE_ON_HIDE: ArkUI_NavDestinationState =
         ArkUI_NavDestinationState(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NavDestinationState {
     /// The NavDestination is mounted to the component tree.
     pub const ARKUI_NAV_DESTINATION_STATE_ON_APPEAR: ArkUI_NavDestinationState =
         ArkUI_NavDestinationState(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NavDestinationState {
     /// The NavDestination removed from the component tree.
     pub const ARKUI_NAV_DESTINATION_STATE_ON_DISAPPEAR: ArkUI_NavDestinationState =
         ArkUI_NavDestinationState(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NavDestinationState {
     /// Before the NavDestination show.
     pub const ARKUI_NAV_DESTINATION_STATE_ON_WILL_SHOW: ArkUI_NavDestinationState =
         ArkUI_NavDestinationState(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NavDestinationState {
     /// Before the NavDestination hide.
     pub const ARKUI_NAV_DESTINATION_STATE_ON_WILL_HIDE: ArkUI_NavDestinationState =
         ArkUI_NavDestinationState(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NavDestinationState {
     /// Before the NavDestination mount to the component tree.
     pub const ARKUI_NAV_DESTINATION_STATE_ON_WILL_APPEAR: ArkUI_NavDestinationState =
         ArkUI_NavDestinationState(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NavDestinationState {
     /// Before the NavDestination removed from the component tree.
     pub const ARKUI_NAV_DESTINATION_STATE_ON_WILL_DISAPPEAR: ArkUI_NavDestinationState =
         ArkUI_NavDestinationState(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_NavDestinationState {
     /// The NavDestination returns from the component.
     pub const ARKUI_NAV_DESTINATION_STATE_ON_BACK_PRESS: ArkUI_NavDestinationState =
         ArkUI_NavDestinationState(100);
@@ -4118,29 +2678,13 @@ impl ArkUI_RouterPageState {
     /// The Router Page is about to be created.
     pub const ARKUI_ROUTER_PAGE_STATE_ABOUT_TO_APPEAR: ArkUI_RouterPageState =
         ArkUI_RouterPageState(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RouterPageState {
     /// The Router Page is about to be destroyed.
     pub const ARKUI_ROUTER_PAGE_STATE_ABOUT_TO_DISAPPEAR: ArkUI_RouterPageState =
         ArkUI_RouterPageState(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RouterPageState {
     /// The Router Page show.
     pub const ARKUI_ROUTER_PAGE_STATE_ON_SHOW: ArkUI_RouterPageState = ArkUI_RouterPageState(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RouterPageState {
     /// The Router Page hide.
     pub const ARKUI_ROUTER_PAGE_STATE_ON_HIDE: ArkUI_RouterPageState = ArkUI_RouterPageState(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_RouterPageState {
     /// The Router Page returns.
     pub const ARKUI_ROUTER_PAGE_STATE_ON_BACK_PRESS: ArkUI_RouterPageState =
         ArkUI_RouterPageState(4);
@@ -4159,16 +2703,8 @@ pub struct ArkUI_RouterPageState(pub ::core::ffi::c_uint);
 impl ArkUI_SafeAreaType {
     /// The default security zone includes the status bar and navigation bar.
     pub const ARKUI_SAFE_AREA_TYPE_SYSTEM: ArkUI_SafeAreaType = ArkUI_SafeAreaType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SafeAreaType {
     /// Non-secure areas of the device, such as bangs or hole holes.
     pub const ARKUI_SAFE_AREA_TYPE_CUTOUT: ArkUI_SafeAreaType = ArkUI_SafeAreaType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SafeAreaType {
     /// Soft keyboard area.
     pub const ARKUI_SAFE_AREA_TYPE_KEYBOARD: ArkUI_SafeAreaType = ArkUI_SafeAreaType(4);
 }
@@ -4186,22 +2722,10 @@ pub struct ArkUI_SafeAreaType(pub ::core::ffi::c_uint);
 impl ArkUI_SafeAreaEdge {
     /// Upper area.
     pub const ARKUI_SAFE_AREA_EDGE_TOP: ArkUI_SafeAreaEdge = ArkUI_SafeAreaEdge(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SafeAreaEdge {
     /// Lower area.
     pub const ARKUI_SAFE_AREA_EDGE_BOTTOM: ArkUI_SafeAreaEdge = ArkUI_SafeAreaEdge(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SafeAreaEdge {
     /// Front area.
     pub const ARKUI_SAFE_AREA_EDGE_START: ArkUI_SafeAreaEdge = ArkUI_SafeAreaEdge(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_SafeAreaEdge {
     /// Tail area.
     pub const ARKUI_SAFE_AREA_EDGE_END: ArkUI_SafeAreaEdge = ArkUI_SafeAreaEdge(8);
 }

--- a/components/arkui/src/ui_input_event/ui_input_event_ffi.rs
+++ b/components/arkui/src/ui_input_event/ui_input_event_ffi.rs
@@ -13,20 +13,8 @@ pub struct ArkUI_UIInputEvent {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl ArkUI_UIInputEvent_Type {
     pub const ARKUI_UIINPUTEVENT_TYPE_UNKNOWN: ArkUI_UIInputEvent_Type = ArkUI_UIInputEvent_Type(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_UIInputEvent_Type {
     pub const ARKUI_UIINPUTEVENT_TYPE_TOUCH: ArkUI_UIInputEvent_Type = ArkUI_UIInputEvent_Type(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_UIInputEvent_Type {
     pub const ARKUI_UIINPUTEVENT_TYPE_AXIS: ArkUI_UIInputEvent_Type = ArkUI_UIInputEvent_Type(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_UIInputEvent_Type {
     /// Mouse event.
     pub const ARKUI_UIINPUTEVENT_TYPE_MOUSE: ArkUI_UIInputEvent_Type = ArkUI_UIInputEvent_Type(3);
 }
@@ -45,24 +33,12 @@ impl HitTestMode {
     /// Both the node and its child node respond to the hit test of a touch event, but its sibling node is blocked from
     /// the hit test.
     pub const HTM_DEFAULT: HitTestMode = HitTestMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HitTestMode {
     /// The node responds to the hit test of a touch event, but its child node and sibling node are blocked from the hit
     /// test.
     pub const HTM_BLOCK: HitTestMode = HitTestMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HitTestMode {
     /// Both the node and its child node respond to the hit test of a touch event, and its sibling node is also
     /// considered during the hit test.
     pub const HTM_TRANSPARENT: HitTestMode = HitTestMode(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HitTestMode {
     /// The node does not respond to the hit test of a touch event, but its child node and sibling node are considered
     /// during the hit test.
     pub const HTM_NONE: HitTestMode = HitTestMode(3);
@@ -76,30 +52,6 @@ impl HitTestMode {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct HitTestMode(pub ::core::ffi::c_uint);
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ModifierKeyName {
-    /// Ctrl.
-    pub const ARKUI_MODIFIER_KEY_CTRL: ArkUI_ModifierKeyName = ArkUI_ModifierKeyName(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ModifierKeyName {
-    /// Shift.
-    pub const ARKUI_MODIFIER_KEY_SHIFT: ArkUI_ModifierKeyName = ArkUI_ModifierKeyName(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ModifierKeyName {
-    /// Alt.
-    pub const ARKUI_MODIFIER_KEY_ALT: ArkUI_ModifierKeyName = ArkUI_ModifierKeyName(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ArkUI_ModifierKeyName {
-    /// Fn.
-    pub const ARKUI_MODIFIER_KEY_FN: ArkUI_ModifierKeyName = ArkUI_ModifierKeyName(8);
-}
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl ::core::ops::BitOr<ArkUI_ModifierKeyName> for ArkUI_ModifierKeyName {
@@ -133,6 +85,18 @@ impl ::core::ops::BitAndAssign for ArkUI_ModifierKeyName {
     fn bitand_assign(&mut self, rhs: ArkUI_ModifierKeyName) {
         self.0 &= rhs.0;
     }
+}
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
+impl ArkUI_ModifierKeyName {
+    /// Ctrl.
+    pub const ARKUI_MODIFIER_KEY_CTRL: ArkUI_ModifierKeyName = ArkUI_ModifierKeyName(1);
+    /// Shift.
+    pub const ARKUI_MODIFIER_KEY_SHIFT: ArkUI_ModifierKeyName = ArkUI_ModifierKeyName(2);
+    /// Alt.
+    pub const ARKUI_MODIFIER_KEY_ALT: ArkUI_ModifierKeyName = ArkUI_ModifierKeyName(4);
+    /// Fn.
+    pub const ARKUI_MODIFIER_KEY_FN: ArkUI_ModifierKeyName = ArkUI_ModifierKeyName(8);
 }
 #[repr(transparent)]
 /// Defines an enum for modifier keys.

--- a/components/drawing/src/canvas/canvas_ffi.rs
+++ b/components/drawing/src/canvas/canvas_ffi.rs
@@ -11,10 +11,6 @@ impl OH_Drawing_SrcRectConstraint {
     /// Using sampling only inside bounds in a slower manner.
     pub const STRICT_SRC_RECT_CONSTRAINT: OH_Drawing_SrcRectConstraint =
         OH_Drawing_SrcRectConstraint(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_SrcRectConstraint {
     /// Using sampling outside bounds in a faster manner.
     pub const FAST_SRC_RECT_CONSTRAINT: OH_Drawing_SrcRectConstraint =
         OH_Drawing_SrcRectConstraint(1);
@@ -35,16 +31,8 @@ pub struct OH_Drawing_SrcRectConstraint(pub ::core::ffi::c_uint);
 impl OH_Drawing_PointMode {
     /// Draw each point separately.
     pub const POINT_MODE_POINTS: OH_Drawing_PointMode = OH_Drawing_PointMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PointMode {
     /// Draw each pair of points as a line segment.
     pub const POINT_MODE_LINES: OH_Drawing_PointMode = OH_Drawing_PointMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PointMode {
     /// Draw the array of points as a open polygon.
     pub const POINT_MODE_POLYGON: OH_Drawing_PointMode = OH_Drawing_PointMode(2);
 }
@@ -65,10 +53,6 @@ pub struct OH_Drawing_PointMode(pub ::core::ffi::c_uint);
 impl OH_Drawing_CanvasClipOp {
     /// Clip with difference.
     pub const DIFFERENCE: OH_Drawing_CanvasClipOp = OH_Drawing_CanvasClipOp(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_CanvasClipOp {
     /// Clip with intersection.
     pub const INTERSECT: OH_Drawing_CanvasClipOp = OH_Drawing_CanvasClipOp(1);
 }
@@ -88,24 +72,12 @@ pub struct OH_Drawing_CanvasClipOp(pub ::core::ffi::c_uint);
 impl OH_Drawing_CanvasShadowFlags {
     /// Use no shadow flags.
     pub const SHADOW_FLAGS_NONE: OH_Drawing_CanvasShadowFlags = OH_Drawing_CanvasShadowFlags(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_CanvasShadowFlags {
     /// The occluding object is transparent.
     pub const SHADOW_FLAGS_TRANSPARENT_OCCLUDER: OH_Drawing_CanvasShadowFlags =
         OH_Drawing_CanvasShadowFlags(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_CanvasShadowFlags {
     /// No need to analyze shadows.
     pub const SHADOW_FLAGS_GEOMETRIC_ONLY: OH_Drawing_CanvasShadowFlags =
         OH_Drawing_CanvasShadowFlags(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_CanvasShadowFlags {
     /// Use all shadow flags.
     pub const SHADOW_FLAGS_ALL: OH_Drawing_CanvasShadowFlags = OH_Drawing_CanvasShadowFlags(3);
 }
@@ -125,16 +97,8 @@ pub struct OH_Drawing_CanvasShadowFlags(pub ::core::ffi::c_uint);
 impl OH_Drawing_VertexMode {
     /// The vertices are a triangle list.
     pub const VERTEX_MODE_TRIANGLES: OH_Drawing_VertexMode = OH_Drawing_VertexMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_VertexMode {
     /// The vertices are a triangle strip.
     pub const VERTEX_MODE_TRIANGLES_STRIP: OH_Drawing_VertexMode = OH_Drawing_VertexMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_VertexMode {
     /// The vertices are a triangle fan.
     pub const VERTEX_MODE_TRIANGLE_FAN: OH_Drawing_VertexMode = OH_Drawing_VertexMode(2);
 }

--- a/components/drawing/src/error_code/error_code_ffi.rs
+++ b/components/drawing/src/error_code/error_code_ffi.rs
@@ -5,30 +5,19 @@
 #![allow(non_snake_case)]
 use crate::types::*;
 
+pub type DrawingResult = Result<(), DrawingErrorCode>;
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl DrawingErrorCode {
     /// Permission verification failed.
     pub const NO_PERMISSION: DrawingErrorCode =
         DrawingErrorCode(const { core::num::NonZero::new(201).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl DrawingErrorCode {
     /// Invalid input parameter. For example, the pointer in the parameter is a nullptr.
     pub const INVALID_PARAMETER: DrawingErrorCode =
         DrawingErrorCode(const { core::num::NonZero::new(401).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl DrawingErrorCode {
     /// The parameter is not in the valid range.
     pub const PARAMETER_OUT_OF_RANGE: DrawingErrorCode =
         DrawingErrorCode(const { core::num::NonZero::new(26200001).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl DrawingErrorCode {
     /// mem allocate failed.
     ///
     /// Available since API-level: 13
@@ -37,7 +26,6 @@ impl DrawingErrorCode {
     pub const ALLOCATION_FAILED: DrawingErrorCode =
         DrawingErrorCode(const { core::num::NonZero::new(26200002).unwrap() });
 }
-pub type DrawingResult = Result<(), DrawingErrorCode>;
 #[repr(transparent)]
 /// Enumerates error codes of drawing.
 ///

--- a/components/drawing/src/font/font_ffi.rs
+++ b/components/drawing/src/font/font_ffi.rs
@@ -10,22 +10,10 @@ use crate::types::*;
 impl OH_Drawing_FontHinting {
     /// glyph outlines unchanged
     pub const FONT_HINTING_NONE: OH_Drawing_FontHinting = OH_Drawing_FontHinting(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontHinting {
     /// minimal modification to improve contrast
     pub const FONT_HINTING_SLIGHT: OH_Drawing_FontHinting = OH_Drawing_FontHinting(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontHinting {
     /// glyph outlines modified to improve contrast
     pub const FONT_HINTING_NORMAL: OH_Drawing_FontHinting = OH_Drawing_FontHinting(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontHinting {
     /// modifies glyph outlines for maximum contrast
     pub const FONT_HINTING_FULL: OH_Drawing_FontHinting = OH_Drawing_FontHinting(3);
 }
@@ -45,16 +33,8 @@ pub struct OH_Drawing_FontHinting(pub ::core::ffi::c_uint);
 impl OH_Drawing_FontEdging {
     /// no transparent pixels on glyph edges
     pub const FONT_EDGING_ALIAS: OH_Drawing_FontEdging = OH_Drawing_FontEdging(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontEdging {
     /// may have transparent pixels on glyph edges
     pub const FONT_EDGING_ANTI_ALIAS: OH_Drawing_FontEdging = OH_Drawing_FontEdging(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontEdging {
     /// glyph positioned in pixel using transparency
     pub const FONT_EDGING_SUBPIXEL_ANTI_ALIAS: OH_Drawing_FontEdging = OH_Drawing_FontEdging(2);
 }

--- a/components/drawing/src/mask_filter/mask_filter_ffi.rs
+++ b/components/drawing/src/mask_filter/mask_filter_ffi.rs
@@ -10,22 +10,10 @@ use crate::types::*;
 impl OH_Drawing_BlurType {
     /// Fuzzy inside and outside.
     pub const NORMAL: OH_Drawing_BlurType = OH_Drawing_BlurType(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlurType {
     /// Solid inside, fuzzy outside.
     pub const SOLID: OH_Drawing_BlurType = OH_Drawing_BlurType(1);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlurType {
     /// Nothing inside, fuzzy outside.
     pub const OUTER: OH_Drawing_BlurType = OH_Drawing_BlurType(2);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlurType {
     /// Fuzzy inside, nothing outside.
     pub const INNER: OH_Drawing_BlurType = OH_Drawing_BlurType(3);
 }

--- a/components/drawing/src/matrix/matrix_ffi.rs
+++ b/components/drawing/src/matrix/matrix_ffi.rs
@@ -10,22 +10,10 @@ use crate::types::*;
 impl OH_Drawing_ScaleToFit {
     /// Scales in x and y to fill destination rect.
     pub const SCALE_TO_FIT_FILL: OH_Drawing_ScaleToFit = OH_Drawing_ScaleToFit(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_ScaleToFit {
     /// Scales and aligns to left and top.
     pub const SCALE_TO_FIT_START: OH_Drawing_ScaleToFit = OH_Drawing_ScaleToFit(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_ScaleToFit {
     /// Scales and aligns to center.
     pub const SCALE_TO_FIT_CENTER: OH_Drawing_ScaleToFit = OH_Drawing_ScaleToFit(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_ScaleToFit {
     /// Scales and aligns to right and bottom.
     pub const SCALE_TO_FIT_END: OH_Drawing_ScaleToFit = OH_Drawing_ScaleToFit(3);
 }

--- a/components/drawing/src/path/path_ffi.rs
+++ b/components/drawing/src/path/path_ffi.rs
@@ -10,10 +10,6 @@ use crate::types::*;
 impl OH_Drawing_PathDirection {
     /// clockwise direction for adding closed contours
     pub const PATH_DIRECTION_CW: OH_Drawing_PathDirection = OH_Drawing_PathDirection(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PathDirection {
     /// counter-clockwise direction for adding closed contours
     pub const PATH_DIRECTION_CCW: OH_Drawing_PathDirection = OH_Drawing_PathDirection(1);
 }
@@ -33,22 +29,10 @@ pub struct OH_Drawing_PathDirection(pub ::core::ffi::c_uint);
 impl OH_Drawing_PathFillType {
     /// Specifies that "inside" is computed by a non-zero sum of signed edge crossings
     pub const PATH_FILL_TYPE_WINDING: OH_Drawing_PathFillType = OH_Drawing_PathFillType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PathFillType {
     /// Specifies that "inside" is computed by an odd number of edge crossings
     pub const PATH_FILL_TYPE_EVEN_ODD: OH_Drawing_PathFillType = OH_Drawing_PathFillType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PathFillType {
     /// Same as Winding, but draws outside of the path, rather than inside
     pub const PATH_FILL_TYPE_INVERSE_WINDING: OH_Drawing_PathFillType = OH_Drawing_PathFillType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PathFillType {
     /// Same as EvenOdd, but draws outside of the path, rather than inside
     pub const PATH_FILL_TYPE_INVERSE_EVEN_ODD: OH_Drawing_PathFillType = OH_Drawing_PathFillType(3);
 }
@@ -68,10 +52,6 @@ pub struct OH_Drawing_PathFillType(pub ::core::ffi::c_uint);
 impl OH_Drawing_PathAddMode {
     /// Appended to destination unaltered
     pub const PATH_ADD_MODE_APPEND: OH_Drawing_PathAddMode = OH_Drawing_PathAddMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PathAddMode {
     /// Add line if prior contour is not closed
     pub const PATH_ADD_MODE_EXTEND: OH_Drawing_PathAddMode = OH_Drawing_PathAddMode(1);
 }
@@ -91,28 +71,12 @@ pub struct OH_Drawing_PathAddMode(pub ::core::ffi::c_uint);
 impl OH_Drawing_PathOpMode {
     /// Difference operation.
     pub const PATH_OP_MODE_DIFFERENCE: OH_Drawing_PathOpMode = OH_Drawing_PathOpMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PathOpMode {
     /// Intersect operation.
     pub const PATH_OP_MODE_INTERSECT: OH_Drawing_PathOpMode = OH_Drawing_PathOpMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PathOpMode {
     /// Union operation.
     pub const PATH_OP_MODE_UNION: OH_Drawing_PathOpMode = OH_Drawing_PathOpMode(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PathOpMode {
     /// Xor operation.
     pub const PATH_OP_MODE_XOR: OH_Drawing_PathOpMode = OH_Drawing_PathOpMode(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PathOpMode {
     /// Reverse difference operation.
     pub const PATH_OP_MODE_REVERSE_DIFFERENCE: OH_Drawing_PathOpMode = OH_Drawing_PathOpMode(4);
 }
@@ -133,17 +97,9 @@ impl OH_Drawing_PathMeasureMatrixFlags {
     /// Gets position.
     pub const GET_POSITION_MATRIX: OH_Drawing_PathMeasureMatrixFlags =
         OH_Drawing_PathMeasureMatrixFlags(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PathMeasureMatrixFlags {
     /// Gets tangent.
     pub const GET_TANGENT_MATRIX: OH_Drawing_PathMeasureMatrixFlags =
         OH_Drawing_PathMeasureMatrixFlags(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_PathMeasureMatrixFlags {
     /// Gets both position and tangent.
     pub const GET_POSITION_AND_TANGENT_MATRIX: OH_Drawing_PathMeasureMatrixFlags =
         OH_Drawing_PathMeasureMatrixFlags(2);

--- a/components/drawing/src/pen/pen_ffi.rs
+++ b/components/drawing/src/pen/pen_ffi.rs
@@ -8,13 +8,9 @@ use crate::types::*;
 impl OH_Drawing_PenLineCapStyle {
     /// There is no cap style. Both ends of the line segment are cut off square.
     pub const LINE_FLAT_CAP: OH_Drawing_PenLineCapStyle = OH_Drawing_PenLineCapStyle(0);
-}
-impl OH_Drawing_PenLineCapStyle {
     /// Square cap style. Both ends have a square, the height of which
     /// is half of the width of the line segment, with the same width.
     pub const LINE_SQUARE_CAP: OH_Drawing_PenLineCapStyle = OH_Drawing_PenLineCapStyle(1);
-}
-impl OH_Drawing_PenLineCapStyle {
     /// Round cap style. Both ends have a semicircle centered, the diameter of which
     /// is the same as the width of the line segment.
     pub const LINE_ROUND_CAP: OH_Drawing_PenLineCapStyle = OH_Drawing_PenLineCapStyle(2);
@@ -33,12 +29,8 @@ impl OH_Drawing_PenLineJoinStyle {
     /// Mitered corner. If the angle of a polyline is small, its miter length may be inappropriate.
     /// In this case, you need to use the miter limit to limit the miter length.
     pub const LINE_MITER_JOIN: OH_Drawing_PenLineJoinStyle = OH_Drawing_PenLineJoinStyle(0);
-}
-impl OH_Drawing_PenLineJoinStyle {
     /// Round corner.
     pub const LINE_ROUND_JOIN: OH_Drawing_PenLineJoinStyle = OH_Drawing_PenLineJoinStyle(1);
-}
-impl OH_Drawing_PenLineJoinStyle {
     /// Beveled corner.
     pub const LINE_BEVEL_JOIN: OH_Drawing_PenLineJoinStyle = OH_Drawing_PenLineJoinStyle(2);
 }

--- a/components/drawing/src/region/region_ffi.rs
+++ b/components/drawing/src/region/region_ffi.rs
@@ -10,35 +10,15 @@ use crate::types::*;
 impl OH_Drawing_RegionOpMode {
     /// Difference operation.
     pub const REGION_OP_MODE_DIFFERENCE: OH_Drawing_RegionOpMode = OH_Drawing_RegionOpMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_RegionOpMode {
     /// Intersect operation.
     pub const REGION_OP_MODE_INTERSECT: OH_Drawing_RegionOpMode = OH_Drawing_RegionOpMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_RegionOpMode {
     /// Union operation.
     pub const REGION_OP_MODE_UNION: OH_Drawing_RegionOpMode = OH_Drawing_RegionOpMode(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_RegionOpMode {
     /// Xor operation.
     pub const REGION_OP_MODE_XOR: OH_Drawing_RegionOpMode = OH_Drawing_RegionOpMode(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_RegionOpMode {
     /// Reverse difference operation.
     pub const REGION_OP_MODE_REVERSE_DIFFERENCE: OH_Drawing_RegionOpMode =
         OH_Drawing_RegionOpMode(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_RegionOpMode {
     /// Replace operation.
     pub const REGION_OP_MODE_REPLACE: OH_Drawing_RegionOpMode = OH_Drawing_RegionOpMode(5);
 }

--- a/components/drawing/src/round_rect/round_rect_ffi.rs
+++ b/components/drawing/src/round_rect/round_rect_ffi.rs
@@ -10,22 +10,10 @@ use crate::types::*;
 impl OH_Drawing_CornerPos {
     /// Index of top-left corner radii.
     pub const CORNER_POS_TOP_LEFT: OH_Drawing_CornerPos = OH_Drawing_CornerPos(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_CornerPos {
     /// Index of top-right corner radii.
     pub const CORNER_POS_TOP_RIGHT: OH_Drawing_CornerPos = OH_Drawing_CornerPos(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_CornerPos {
     /// Index of bottom-right corner radii.
     pub const CORNER_POS_BOTTOM_RIGHT: OH_Drawing_CornerPos = OH_Drawing_CornerPos(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_CornerPos {
     /// Index of bottom-left corner radii.
     pub const CORNER_POS_BOTTOM_LEFT: OH_Drawing_CornerPos = OH_Drawing_CornerPos(3);
 }

--- a/components/drawing/src/sampling_options/sampling_options_ffi.rs
+++ b/components/drawing/src/sampling_options/sampling_options_ffi.rs
@@ -10,10 +10,6 @@ use crate::types::*;
 impl OH_Drawing_FilterMode {
     /// single sample point (nearest neighbor)
     pub const FILTER_MODE_NEAREST: OH_Drawing_FilterMode = OH_Drawing_FilterMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FilterMode {
     /// interporate between 2x2 sample points (bilinear interpolation)
     pub const FILTER_MODE_LINEAR: OH_Drawing_FilterMode = OH_Drawing_FilterMode(1);
 }
@@ -33,16 +29,8 @@ pub struct OH_Drawing_FilterMode(pub ::core::ffi::c_uint);
 impl OH_Drawing_MipmapMode {
     /// ignore mipmap levels, sample from the "base"
     pub const MIPMAP_MODE_NONE: OH_Drawing_MipmapMode = OH_Drawing_MipmapMode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_MipmapMode {
     /// sample from the nearest level
     pub const MIPMAP_MODE_NEAREST: OH_Drawing_MipmapMode = OH_Drawing_MipmapMode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_MipmapMode {
     /// interpolate between the two nearest levels
     pub const MIPMAP_MODE_LINEAR: OH_Drawing_MipmapMode = OH_Drawing_MipmapMode(2);
 }

--- a/components/drawing/src/shader_effect/shader_effect_ffi.rs
+++ b/components/drawing/src/shader_effect/shader_effect_ffi.rs
@@ -10,23 +10,11 @@ use crate::types::*;
 impl OH_Drawing_TileMode {
     /// Replicate the edge color if the shader effect draws outside of its original bounds.
     pub const CLAMP: OH_Drawing_TileMode = OH_Drawing_TileMode(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_TileMode {
     /// Repeat the shader effect image horizontally and vertically.
     pub const REPEAT: OH_Drawing_TileMode = OH_Drawing_TileMode(1);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_TileMode {
     /// Repeat the shader effect image horizontally and vertically, alternating mirror images
     /// so that adjacent images always seam.
     pub const MIRROR: OH_Drawing_TileMode = OH_Drawing_TileMode(2);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_TileMode {
     /// Only draw within the original domain, return transparent-black everywhere else.
     pub const DECAL: OH_Drawing_TileMode = OH_Drawing_TileMode(3);
 }

--- a/components/drawing/src/text_font_descriptor/text_font_descriptor_ffi.rs
+++ b/components/drawing/src/text_font_descriptor/text_font_descriptor_ffi.rs
@@ -11,22 +11,10 @@ use crate::types::*;
 impl OH_Drawing_SystemFontType {
     /// All font types
     pub const ALL: OH_Drawing_SystemFontType = OH_Drawing_SystemFontType(1);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl OH_Drawing_SystemFontType {
     /// System generic font type
     pub const GENERIC: OH_Drawing_SystemFontType = OH_Drawing_SystemFontType(2);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl OH_Drawing_SystemFontType {
     /// Stylish font type
     pub const STYLISH: OH_Drawing_SystemFontType = OH_Drawing_SystemFontType(4);
-}
-#[cfg(feature = "api-14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
-impl OH_Drawing_SystemFontType {
     /// Installed font types
     pub const INSTALLED: OH_Drawing_SystemFontType = OH_Drawing_SystemFontType(8);
 }

--- a/components/drawing/src/text_typography/text_typography_ffi.rs
+++ b/components/drawing/src/text_typography/text_typography_ffi.rs
@@ -11,8 +11,6 @@ use crate::types::*;
 impl OH_Drawing_TextDirection {
     /// Right to left (RTL)
     pub const TEXT_DIRECTION_RTL: OH_Drawing_TextDirection = OH_Drawing_TextDirection(0);
-}
-impl OH_Drawing_TextDirection {
     /// Left to right (LTR)
     pub const TEXT_DIRECTION_LTR: OH_Drawing_TextDirection = OH_Drawing_TextDirection(1);
 }
@@ -28,28 +26,18 @@ pub struct OH_Drawing_TextDirection(pub ::core::ffi::c_uint);
 impl OH_Drawing_TextAlign {
     /// Left-aligned
     pub const TEXT_ALIGN_LEFT: OH_Drawing_TextAlign = OH_Drawing_TextAlign(0);
-}
-impl OH_Drawing_TextAlign {
     /// Right-aligned
     pub const TEXT_ALIGN_RIGHT: OH_Drawing_TextAlign = OH_Drawing_TextAlign(1);
-}
-impl OH_Drawing_TextAlign {
     /// Center-aligned
     pub const TEXT_ALIGN_CENTER: OH_Drawing_TextAlign = OH_Drawing_TextAlign(2);
-}
-impl OH_Drawing_TextAlign {
     /// Justified, which means that each line (except the last line) is stretched so that every line has equal width,
     /// and the left and right margins are straight.
     pub const TEXT_ALIGN_JUSTIFY: OH_Drawing_TextAlign = OH_Drawing_TextAlign(3);
-}
-impl OH_Drawing_TextAlign {
     /// <b>TEXT_ALIGN_START</b> achieves the same effect as <b>TEXT_ALIGN_LEFT</b>
     /// when <b>OH_Drawing_TextDirection</b> is <b>TEXT_DIRECTION_LTR</b>;
     /// it achieves the same effect as <b>TEXT_ALIGN_RIGHT</b>
     /// when <b>OH_Drawing_TextDirection</b> is <b>TEXT_DIRECTION_RTL</b>.
     pub const TEXT_ALIGN_START: OH_Drawing_TextAlign = OH_Drawing_TextAlign(4);
-}
-impl OH_Drawing_TextAlign {
     /// <b>TEXT_ALIGN_END</b> achieves the same effect as <b>TEXT_ALIGN_RIGHT</b>
     /// when <b>OH_Drawing_TextDirection</b> is <b>TEXT_DIRECTION_LTR</b>;
     /// it achieves the same effect as <b>TEXT_ALIGN_LEFT</b>
@@ -68,36 +56,20 @@ pub struct OH_Drawing_TextAlign(pub ::core::ffi::c_uint);
 impl OH_Drawing_FontWeight {
     /// Thin
     pub const FONT_WEIGHT_100: OH_Drawing_FontWeight = OH_Drawing_FontWeight(0);
-}
-impl OH_Drawing_FontWeight {
     /// Extra-light
     pub const FONT_WEIGHT_200: OH_Drawing_FontWeight = OH_Drawing_FontWeight(1);
-}
-impl OH_Drawing_FontWeight {
     /// Light
     pub const FONT_WEIGHT_300: OH_Drawing_FontWeight = OH_Drawing_FontWeight(2);
-}
-impl OH_Drawing_FontWeight {
     /// Normal/Regular
     pub const FONT_WEIGHT_400: OH_Drawing_FontWeight = OH_Drawing_FontWeight(3);
-}
-impl OH_Drawing_FontWeight {
     /// Medium
     pub const FONT_WEIGHT_500: OH_Drawing_FontWeight = OH_Drawing_FontWeight(4);
-}
-impl OH_Drawing_FontWeight {
     /// Semi-bold
     pub const FONT_WEIGHT_600: OH_Drawing_FontWeight = OH_Drawing_FontWeight(5);
-}
-impl OH_Drawing_FontWeight {
     /// Bold
     pub const FONT_WEIGHT_700: OH_Drawing_FontWeight = OH_Drawing_FontWeight(6);
-}
-impl OH_Drawing_FontWeight {
     /// Extra-bold
     pub const FONT_WEIGHT_800: OH_Drawing_FontWeight = OH_Drawing_FontWeight(7);
-}
-impl OH_Drawing_FontWeight {
     /// Black
     pub const FONT_WEIGHT_900: OH_Drawing_FontWeight = OH_Drawing_FontWeight(8);
 }
@@ -113,8 +85,6 @@ pub struct OH_Drawing_FontWeight(pub ::core::ffi::c_uint);
 impl OH_Drawing_TextBaseline {
     /// Alphabetic, where the letters in alphabets like English sit on.
     pub const TEXT_BASELINE_ALPHABETIC: OH_Drawing_TextBaseline = OH_Drawing_TextBaseline(0);
-}
-impl OH_Drawing_TextBaseline {
     /// Ideographic. The baseline is at the bottom of the text area.
     pub const TEXT_BASELINE_IDEOGRAPHIC: OH_Drawing_TextBaseline = OH_Drawing_TextBaseline(1);
 }
@@ -130,16 +100,10 @@ pub struct OH_Drawing_TextBaseline(pub ::core::ffi::c_uint);
 impl OH_Drawing_TextDecoration {
     /// No decoration.
     pub const TEXT_DECORATION_NONE: OH_Drawing_TextDecoration = OH_Drawing_TextDecoration(0);
-}
-impl OH_Drawing_TextDecoration {
     /// A underline is used for decoration.
     pub const TEXT_DECORATION_UNDERLINE: OH_Drawing_TextDecoration = OH_Drawing_TextDecoration(1);
-}
-impl OH_Drawing_TextDecoration {
     /// An overline is used for decoration.
     pub const TEXT_DECORATION_OVERLINE: OH_Drawing_TextDecoration = OH_Drawing_TextDecoration(2);
-}
-impl OH_Drawing_TextDecoration {
     /// A strikethrough is used for decoration.
     pub const TEXT_DECORATION_LINE_THROUGH: OH_Drawing_TextDecoration =
         OH_Drawing_TextDecoration(4);
@@ -156,12 +120,8 @@ pub struct OH_Drawing_TextDecoration(pub ::core::ffi::c_uint);
 impl OH_Drawing_FontStyle {
     /// Normal style
     pub const FONT_STYLE_NORMAL: OH_Drawing_FontStyle = OH_Drawing_FontStyle(0);
-}
-impl OH_Drawing_FontStyle {
     /// Italic style
     pub const FONT_STYLE_ITALIC: OH_Drawing_FontStyle = OH_Drawing_FontStyle(1);
-}
-impl OH_Drawing_FontStyle {
     /// Oblique style
     pub const FONT_STYLE_OBLIQUE: OH_Drawing_FontStyle = OH_Drawing_FontStyle(2);
 }
@@ -180,38 +140,18 @@ impl OH_Drawing_PlaceholderVerticalAlignment {
     /// Offset At Baseline
     pub const ALIGNMENT_OFFSET_AT_BASELINE: OH_Drawing_PlaceholderVerticalAlignment =
         OH_Drawing_PlaceholderVerticalAlignment(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_PlaceholderVerticalAlignment {
     /// Above Baseline
     pub const ALIGNMENT_ABOVE_BASELINE: OH_Drawing_PlaceholderVerticalAlignment =
         OH_Drawing_PlaceholderVerticalAlignment(1);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_PlaceholderVerticalAlignment {
     /// Below Baseline
     pub const ALIGNMENT_BELOW_BASELINE: OH_Drawing_PlaceholderVerticalAlignment =
         OH_Drawing_PlaceholderVerticalAlignment(2);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_PlaceholderVerticalAlignment {
     /// Top of Row Box
     pub const ALIGNMENT_TOP_OF_ROW_BOX: OH_Drawing_PlaceholderVerticalAlignment =
         OH_Drawing_PlaceholderVerticalAlignment(3);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_PlaceholderVerticalAlignment {
     /// Bottom of Row Box
     pub const ALIGNMENT_BOTTOM_OF_ROW_BOX: OH_Drawing_PlaceholderVerticalAlignment =
         OH_Drawing_PlaceholderVerticalAlignment(4);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_PlaceholderVerticalAlignment {
     /// Center of Row Box
     pub const ALIGNMENT_CENTER_OF_ROW_BOX: OH_Drawing_PlaceholderVerticalAlignment =
         OH_Drawing_PlaceholderVerticalAlignment(5);
@@ -255,31 +195,15 @@ impl OH_Drawing_TextDecorationStyle {
     /// Solid style
     pub const TEXT_DECORATION_STYLE_SOLID: OH_Drawing_TextDecorationStyle =
         OH_Drawing_TextDecorationStyle(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_TextDecorationStyle {
     /// Double style
     pub const TEXT_DECORATION_STYLE_DOUBLE: OH_Drawing_TextDecorationStyle =
         OH_Drawing_TextDecorationStyle(1);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_TextDecorationStyle {
     /// Dotted style
     pub const TEXT_DECORATION_STYLE_DOTTED: OH_Drawing_TextDecorationStyle =
         OH_Drawing_TextDecorationStyle(2);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_TextDecorationStyle {
     /// Dashed style
     pub const TEXT_DECORATION_STYLE_DASHED: OH_Drawing_TextDecorationStyle =
         OH_Drawing_TextDecorationStyle(3);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_TextDecorationStyle {
     /// Wavy style
     pub const TEXT_DECORATION_STYLE_WAVY: OH_Drawing_TextDecorationStyle =
         OH_Drawing_TextDecorationStyle(4);
@@ -300,16 +224,8 @@ pub struct OH_Drawing_TextDecorationStyle(pub ::core::ffi::c_uint);
 impl OH_Drawing_EllipsisModal {
     /// Head modal
     pub const ELLIPSIS_MODAL_HEAD: OH_Drawing_EllipsisModal = OH_Drawing_EllipsisModal(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_EllipsisModal {
     /// Middle modal
     pub const ELLIPSIS_MODAL_MIDDLE: OH_Drawing_EllipsisModal = OH_Drawing_EllipsisModal(1);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_EllipsisModal {
     /// Tail modal
     pub const ELLIPSIS_MODAL_TAIL: OH_Drawing_EllipsisModal = OH_Drawing_EllipsisModal(2);
 }
@@ -329,16 +245,8 @@ pub struct OH_Drawing_EllipsisModal(pub ::core::ffi::c_uint);
 impl OH_Drawing_BreakStrategy {
     /// Greedy strategy
     pub const BREAK_STRATEGY_GREEDY: OH_Drawing_BreakStrategy = OH_Drawing_BreakStrategy(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BreakStrategy {
     /// Quality strategy
     pub const BREAK_STRATEGY_HIGH_QUALITY: OH_Drawing_BreakStrategy = OH_Drawing_BreakStrategy(1);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BreakStrategy {
     /// Balanced strategy
     pub const BREAK_STRATEGY_BALANCED: OH_Drawing_BreakStrategy = OH_Drawing_BreakStrategy(2);
 }
@@ -358,16 +266,8 @@ pub struct OH_Drawing_BreakStrategy(pub ::core::ffi::c_uint);
 impl OH_Drawing_WordBreakType {
     /// Normal type
     pub const WORD_BREAK_TYPE_NORMAL: OH_Drawing_WordBreakType = OH_Drawing_WordBreakType(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_WordBreakType {
     /// Break All type
     pub const WORD_BREAK_TYPE_BREAK_ALL: OH_Drawing_WordBreakType = OH_Drawing_WordBreakType(1);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_WordBreakType {
     /// Break Word type
     pub const WORD_BREAK_TYPE_BREAK_WORD: OH_Drawing_WordBreakType = OH_Drawing_WordBreakType(2);
 }
@@ -387,37 +287,17 @@ pub struct OH_Drawing_WordBreakType(pub ::core::ffi::c_uint);
 impl OH_Drawing_RectHeightStyle {
     /// Tight style
     pub const RECT_HEIGHT_STYLE_TIGHT: OH_Drawing_RectHeightStyle = OH_Drawing_RectHeightStyle(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_RectHeightStyle {
     /// Max style
     pub const RECT_HEIGHT_STYLE_MAX: OH_Drawing_RectHeightStyle = OH_Drawing_RectHeightStyle(1);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_RectHeightStyle {
     /// Includelinespacemiddle style
     pub const RECT_HEIGHT_STYLE_INCLUDELINESPACEMIDDLE: OH_Drawing_RectHeightStyle =
         OH_Drawing_RectHeightStyle(2);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_RectHeightStyle {
     /// Includelinespacetop style
     pub const RECT_HEIGHT_STYLE_INCLUDELINESPACETOP: OH_Drawing_RectHeightStyle =
         OH_Drawing_RectHeightStyle(3);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_RectHeightStyle {
     /// Includelinespacebottom style
     pub const RECT_HEIGHT_STYLE_INCLUDELINESPACEBOTTOM: OH_Drawing_RectHeightStyle =
         OH_Drawing_RectHeightStyle(4);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_RectHeightStyle {
     /// Struct style
     pub const RECT_HEIGHT_STYLE_STRUCT: OH_Drawing_RectHeightStyle = OH_Drawing_RectHeightStyle(5);
 }
@@ -437,10 +317,6 @@ pub struct OH_Drawing_RectHeightStyle(pub ::core::ffi::c_uint);
 impl OH_Drawing_RectWidthStyle {
     /// Tight style
     pub const RECT_WIDTH_STYLE_TIGHT: OH_Drawing_RectWidthStyle = OH_Drawing_RectWidthStyle(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_RectWidthStyle {
     /// Max style
     pub const RECT_WIDTH_STYLE_MAX: OH_Drawing_RectWidthStyle = OH_Drawing_RectWidthStyle(1);
 }
@@ -461,30 +337,14 @@ impl OH_Drawing_FontConfigInfoErrorCode {
     /// The list of system font configuration information was successfully obtained
     pub const SUCCESS_FONT_CONFIG_INFO: OH_Drawing_FontConfigInfoErrorCode =
         OH_Drawing_FontConfigInfoErrorCode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontConfigInfoErrorCode {
     /// Unknown error
     pub const UNKNOWN: OH_Drawing_FontConfigInfoErrorCode = OH_Drawing_FontConfigInfoErrorCode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontConfigInfoErrorCode {
     /// Parse system config file error
     pub const PARSE_FILE: OH_Drawing_FontConfigInfoErrorCode =
         OH_Drawing_FontConfigInfoErrorCode(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontConfigInfoErrorCode {
     /// Alloc memory error
     pub const ALLOC_MEMORY: OH_Drawing_FontConfigInfoErrorCode =
         OH_Drawing_FontConfigInfoErrorCode(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontConfigInfoErrorCode {
     /// Copy string data error
     pub const COPY_STRING_DATA: OH_Drawing_FontConfigInfoErrorCode =
         OH_Drawing_FontConfigInfoErrorCode(4);
@@ -684,24 +544,12 @@ pub struct OH_Drawing_LineMetrics {
 impl OH_Drawing_TextHeightBehavior {
     /// both ascend of first row and last row style
     pub const TEXT_HEIGHT_ALL: OH_Drawing_TextHeightBehavior = OH_Drawing_TextHeightBehavior(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextHeightBehavior {
     /// forbidding ascend of first row style
     pub const TEXT_HEIGHT_DISABLE_FIRST_ASCENT: OH_Drawing_TextHeightBehavior =
         OH_Drawing_TextHeightBehavior(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextHeightBehavior {
     /// forbidding ascend of last row style
     pub const TEXT_HEIGHT_DISABLE_LAST_ASCENT: OH_Drawing_TextHeightBehavior =
         OH_Drawing_TextHeightBehavior(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextHeightBehavior {
     /// neither ascend of first row nor last row style
     pub const TEXT_HEIGHT_DISABLE_ALL: OH_Drawing_TextHeightBehavior =
         OH_Drawing_TextHeightBehavior(3);
@@ -722,52 +570,20 @@ pub struct OH_Drawing_TextHeightBehavior(pub ::core::ffi::c_uint);
 impl OH_Drawing_TextStyleType {
     /// None style
     pub const TEXT_STYLE_NONE: OH_Drawing_TextStyleType = OH_Drawing_TextStyleType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextStyleType {
     /// All attributes style
     pub const TEXT_STYLE_ALL_ATTRIBUTES: OH_Drawing_TextStyleType = OH_Drawing_TextStyleType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextStyleType {
     /// Font style
     pub const TEXT_STYLE_FONT: OH_Drawing_TextStyleType = OH_Drawing_TextStyleType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextStyleType {
     /// Foreground style
     pub const TEXT_STYLE_FOREGROUND: OH_Drawing_TextStyleType = OH_Drawing_TextStyleType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextStyleType {
     /// Background style
     pub const TEXT_STYLE_BACKGROUND: OH_Drawing_TextStyleType = OH_Drawing_TextStyleType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextStyleType {
     /// Shadow style
     pub const TEXT_STYLE_SHADOW: OH_Drawing_TextStyleType = OH_Drawing_TextStyleType(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextStyleType {
     /// Decorations style
     pub const TEXT_STYLE_DECORATIONS: OH_Drawing_TextStyleType = OH_Drawing_TextStyleType(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextStyleType {
     /// Letter spacing style
     pub const TEXT_STYLE_LETTER_SPACING: OH_Drawing_TextStyleType = OH_Drawing_TextStyleType(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextStyleType {
     /// Word spacing style
     pub const TEXT_STYLE_WORD_SPACING: OH_Drawing_TextStyleType = OH_Drawing_TextStyleType(8);
 }
@@ -786,45 +602,13 @@ pub struct OH_Drawing_TextStyleType(pub ::core::ffi::c_uint);
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl OH_Drawing_FontWidth {
     pub const FONT_WIDTH_ULTRA_CONDENSED: OH_Drawing_FontWidth = OH_Drawing_FontWidth(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontWidth {
     pub const FONT_WIDTH_EXTRA_CONDENSED: OH_Drawing_FontWidth = OH_Drawing_FontWidth(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontWidth {
     pub const FONT_WIDTH_CONDENSED: OH_Drawing_FontWidth = OH_Drawing_FontWidth(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontWidth {
     pub const FONT_WIDTH_SEMI_CONDENSED: OH_Drawing_FontWidth = OH_Drawing_FontWidth(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontWidth {
     pub const FONT_WIDTH_NORMAL: OH_Drawing_FontWidth = OH_Drawing_FontWidth(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontWidth {
     pub const FONT_WIDTH_SEMI_EXPANDED: OH_Drawing_FontWidth = OH_Drawing_FontWidth(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontWidth {
     pub const FONT_WIDTH_EXPANDED: OH_Drawing_FontWidth = OH_Drawing_FontWidth(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontWidth {
     pub const FONT_WIDTH_EXTRA_EXPANDED: OH_Drawing_FontWidth = OH_Drawing_FontWidth(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_FontWidth {
     pub const FONT_WIDTH_ULTRA_EXPANDED: OH_Drawing_FontWidth = OH_Drawing_FontWidth(9);
 }
 #[repr(transparent)]

--- a/components/drawing/src/types/types_ffi.rs
+++ b/components/drawing/src/types/types_ffi.rs
@@ -161,27 +161,17 @@ pub struct OH_Drawing_Surface {
 impl OH_Drawing_ColorFormat {
     /// Unknown format.
     pub const COLOR_FORMAT_UNKNOWN: OH_Drawing_ColorFormat = OH_Drawing_ColorFormat(0);
-}
-impl OH_Drawing_ColorFormat {
     /// Each pixel is represented by 8 bits, which together indicate alpha.
     pub const COLOR_FORMAT_ALPHA_8: OH_Drawing_ColorFormat = OH_Drawing_ColorFormat(1);
-}
-impl OH_Drawing_ColorFormat {
     /// Each pixel is represented by 16 bits. From the most significant bit to the least significant bit,
     /// the first 5 bits indicate red, the subsequent 6 bits indicate green, and the last 5 bits indicate blue.
     pub const COLOR_FORMAT_RGB_565: OH_Drawing_ColorFormat = OH_Drawing_ColorFormat(2);
-}
-impl OH_Drawing_ColorFormat {
     /// Each pixel is represented by 16 bits. From the most significant bit to the least significant bit,
     /// every 4 bits indicate alpha, red, green, and blue, respectively.
     pub const COLOR_FORMAT_ARGB_4444: OH_Drawing_ColorFormat = OH_Drawing_ColorFormat(3);
-}
-impl OH_Drawing_ColorFormat {
     /// Each pixel is represented by 32 bits. From the most significant bit to the least significant bit,
     /// every 8 bits indicate alpha, red, green, and blue, respectively.
     pub const COLOR_FORMAT_RGBA_8888: OH_Drawing_ColorFormat = OH_Drawing_ColorFormat(4);
-}
-impl OH_Drawing_ColorFormat {
     /// Each pixel is represented by 32 bits. From the most significant bit to the least significant bit,
     /// every 8 bits indicate blue, green, red, and alpha, respectively.
     pub const COLOR_FORMAT_BGRA_8888: OH_Drawing_ColorFormat = OH_Drawing_ColorFormat(5);
@@ -198,16 +188,10 @@ pub struct OH_Drawing_ColorFormat(pub ::core::ffi::c_uint);
 impl OH_Drawing_AlphaFormat {
     /// Unknown format.
     pub const ALPHA_FORMAT_UNKNOWN: OH_Drawing_AlphaFormat = OH_Drawing_AlphaFormat(0);
-}
-impl OH_Drawing_AlphaFormat {
     /// The bitmap does not have the alpha component.
     pub const ALPHA_FORMAT_OPAQUE: OH_Drawing_AlphaFormat = OH_Drawing_AlphaFormat(1);
-}
-impl OH_Drawing_AlphaFormat {
     /// The color component of each pixel is premultiplied by the alpha component.
     pub const ALPHA_FORMAT_PREMUL: OH_Drawing_AlphaFormat = OH_Drawing_AlphaFormat(2);
-}
-impl OH_Drawing_AlphaFormat {
     /// The color component of each pixel is not premultiplied by the alpha component.
     pub const ALPHA_FORMAT_UNPREMUL: OH_Drawing_AlphaFormat = OH_Drawing_AlphaFormat(3);
 }
@@ -225,172 +209,60 @@ pub struct OH_Drawing_AlphaFormat(pub ::core::ffi::c_uint);
 impl OH_Drawing_BlendMode {
     /// r = 0.
     pub const BLEND_MODE_CLEAR: OH_Drawing_BlendMode = OH_Drawing_BlendMode(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = s.
     pub const BLEND_MODE_SRC: OH_Drawing_BlendMode = OH_Drawing_BlendMode(1);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = d.
     pub const BLEND_MODE_DST: OH_Drawing_BlendMode = OH_Drawing_BlendMode(2);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = s + (1-sa)*d.
     pub const BLEND_MODE_SRC_OVER: OH_Drawing_BlendMode = OH_Drawing_BlendMode(3);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = d + (1-da)*s.
     pub const BLEND_MODE_DST_OVER: OH_Drawing_BlendMode = OH_Drawing_BlendMode(4);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = s * da.
     pub const BLEND_MODE_SRC_IN: OH_Drawing_BlendMode = OH_Drawing_BlendMode(5);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = d * sa.
     pub const BLEND_MODE_DST_IN: OH_Drawing_BlendMode = OH_Drawing_BlendMode(6);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = s * (1-da).
     pub const BLEND_MODE_SRC_OUT: OH_Drawing_BlendMode = OH_Drawing_BlendMode(7);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = d * (1-sa).
     pub const BLEND_MODE_DST_OUT: OH_Drawing_BlendMode = OH_Drawing_BlendMode(8);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = s*da + d*(1-sa).
     pub const BLEND_MODE_SRC_ATOP: OH_Drawing_BlendMode = OH_Drawing_BlendMode(9);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = d*sa + s*(1-da).
     pub const BLEND_MODE_DST_ATOP: OH_Drawing_BlendMode = OH_Drawing_BlendMode(10);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = s*(1-da) + d*(1-sa).
     pub const BLEND_MODE_XOR: OH_Drawing_BlendMode = OH_Drawing_BlendMode(11);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = min(s + d, 1).
     pub const BLEND_MODE_PLUS: OH_Drawing_BlendMode = OH_Drawing_BlendMode(12);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = s*d.
     pub const BLEND_MODE_MODULATE: OH_Drawing_BlendMode = OH_Drawing_BlendMode(13);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = s + d - s*d.
     pub const BLEND_MODE_SCREEN: OH_Drawing_BlendMode = OH_Drawing_BlendMode(14);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// multiply or screen, depending on destination.
     pub const BLEND_MODE_OVERLAY: OH_Drawing_BlendMode = OH_Drawing_BlendMode(15);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// rc = s + d - max(s*da, d*sa), ra = s + (1-sa)*d.
     pub const BLEND_MODE_DARKEN: OH_Drawing_BlendMode = OH_Drawing_BlendMode(16);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// rc = s + d - min(s*da, d*sa), ra = s + (1-sa)*d.
     pub const BLEND_MODE_LIGHTEN: OH_Drawing_BlendMode = OH_Drawing_BlendMode(17);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// brighten destination to reflect source.
     pub const BLEND_MODE_COLOR_DODGE: OH_Drawing_BlendMode = OH_Drawing_BlendMode(18);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// darken destination to reflect source.
     pub const BLEND_MODE_COLOR_BURN: OH_Drawing_BlendMode = OH_Drawing_BlendMode(19);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// multiply or screen, depending on source.
     pub const BLEND_MODE_HARD_LIGHT: OH_Drawing_BlendMode = OH_Drawing_BlendMode(20);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// lighten or darken, depending on source.
     pub const BLEND_MODE_SOFT_LIGHT: OH_Drawing_BlendMode = OH_Drawing_BlendMode(21);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// rc = s + d - 2*(min(s*da, d*sa)), ra = s + (1-sa)*d.
     pub const BLEND_MODE_DIFFERENCE: OH_Drawing_BlendMode = OH_Drawing_BlendMode(22);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// rc = s + d - two(s*d), ra = s + (1-sa)*d.
     pub const BLEND_MODE_EXCLUSION: OH_Drawing_BlendMode = OH_Drawing_BlendMode(23);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// r = s*(1-da) + d*(1-sa) + s*d.
     pub const BLEND_MODE_MULTIPLY: OH_Drawing_BlendMode = OH_Drawing_BlendMode(24);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// hue of source with saturation and luminosity of destination.
     pub const BLEND_MODE_HUE: OH_Drawing_BlendMode = OH_Drawing_BlendMode(25);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// saturation of source with hue and luminosity of destination.
     pub const BLEND_MODE_SATURATION: OH_Drawing_BlendMode = OH_Drawing_BlendMode(26);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// hue and saturation of source with luminosity of destination.
     pub const BLEND_MODE_COLOR: OH_Drawing_BlendMode = OH_Drawing_BlendMode(27);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_Drawing_BlendMode {
     /// luminosity of source with hue and saturation of destination.
     pub const BLEND_MODE_LUMINOSITY: OH_Drawing_BlendMode = OH_Drawing_BlendMode(28);
 }
@@ -481,22 +353,10 @@ pub struct OH_Drawing_String {
 impl OH_Drawing_TextEncoding {
     /// uses bytes to represent UTF-8 or ASCII
     pub const TEXT_ENCODING_UTF8: OH_Drawing_TextEncoding = OH_Drawing_TextEncoding(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextEncoding {
     /// uses two byte words to represent most of Unicode
     pub const TEXT_ENCODING_UTF16: OH_Drawing_TextEncoding = OH_Drawing_TextEncoding(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextEncoding {
     /// uses four byte words to represent all of Unicode
     pub const TEXT_ENCODING_UTF32: OH_Drawing_TextEncoding = OH_Drawing_TextEncoding(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Drawing_TextEncoding {
     /// uses two byte words to represent glyph indices
     pub const TEXT_ENCODING_GLYPH_ID: OH_Drawing_TextEncoding = OH_Drawing_TextEncoding(3);
 }

--- a/components/hilog/src/hilog_ffi.rs
+++ b/components/hilog/src/hilog_ffi.rs
@@ -21,20 +21,12 @@ pub struct LogType(pub ::core::ffi::c_uint);
 impl LogLevel {
     /// Debug level to be used by [`OH_LOG_DEBUG`]
     pub const LOG_DEBUG: LogLevel = LogLevel(3);
-}
-impl LogLevel {
     /// Informational level to be used by [`OH_LOG_INFO`]
     pub const LOG_INFO: LogLevel = LogLevel(4);
-}
-impl LogLevel {
     /// Warning level to be used by [`OH_LOG_WARN`]
     pub const LOG_WARN: LogLevel = LogLevel(5);
-}
-impl LogLevel {
     /// Error level to be used by [`OH_LOG_ERROR`]
     pub const LOG_ERROR: LogLevel = LogLevel(6);
-}
-impl LogLevel {
     /// Fatal level to be used by [`OH_LOG_FATAL`]
     pub const LOG_FATAL: LogLevel = LogLevel(7);
 }

--- a/components/hitrace/src/hitrace_ffi.rs
+++ b/components/hitrace/src/hitrace_ffi.rs
@@ -154,10 +154,6 @@ impl HiTraceId_Valid {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const HITRACE_ID_INVALID: HiTraceId_Valid = HiTraceId_Valid(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTraceId_Valid {
     /// Valid <b>HiTraceId</b> instance.
     ///
     ///
@@ -209,120 +205,6 @@ impl HiTrace_Version {
 pub struct HiTrace_Version(pub ::core::ffi::c_uint);
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTrace_Flag {
-    /// Default flag.
-    ///
-    ///
-    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
-    ///
-    ///
-    /// Available since API-level: 12
-    #[cfg(feature = "api-12")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-    pub const HITRACE_FLAG_DEFAULT: HiTrace_Flag = HiTrace_Flag(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTrace_Flag {
-    /// Both synchronous and asynchronous calls are traced. By default, only synchronous calls are traced.
-    ///
-    ///
-    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
-    ///
-    ///
-    /// Available since API-level: 12
-    #[cfg(feature = "api-12")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-    pub const HITRACE_FLAG_INCLUDE_ASYNC: HiTrace_Flag = HiTrace_Flag(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTrace_Flag {
-    /// No spans are created. By default, spans are created.
-    ///
-    ///
-    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
-    ///
-    ///
-    /// Available since API-level: 12
-    #[cfg(feature = "api-12")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-    pub const HITRACE_FLAG_DONOT_CREATE_SPAN: HiTrace_Flag = HiTrace_Flag(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTrace_Flag {
-    /// Trace points are automatically added to spans. By default, no trace point is added.
-    ///
-    ///
-    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
-    ///
-    ///
-    /// Available since API-level: 12
-    #[cfg(feature = "api-12")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-    pub const HITRACE_FLAG_TP_INFO: HiTrace_Flag = HiTrace_Flag(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTrace_Flag {
-    /// Information about the start and end of the trace task is not printed. By default, information about the
-    /// start and end of the trace task is printed.
-    ///
-    ///
-    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
-    ///
-    ///
-    /// Available since API-level: 12
-    #[cfg(feature = "api-12")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-    pub const HITRACE_FLAG_NO_BE_INFO: HiTrace_Flag = HiTrace_Flag(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTrace_Flag {
-    /// The ID is not added to the log. By default, the ID is added to the log.
-    ///
-    ///
-    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
-    ///
-    ///
-    /// Available since API-level: 12
-    #[cfg(feature = "api-12")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-    pub const HITRACE_FLAG_DONOT_ENABLE_LOG: HiTrace_Flag = HiTrace_Flag(16);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTrace_Flag {
-    /// Tracing is triggered by faults.
-    ///
-    ///
-    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
-    ///
-    ///
-    /// Available since API-level: 12
-    #[cfg(feature = "api-12")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-    pub const HITRACE_FLAG_FAULT_TRIGGER: HiTrace_Flag = HiTrace_Flag(32);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTrace_Flag {
-    /// Trace points are added only for call chain trace between devices.
-    /// By default, device-to-device trace points are not added.
-    ///
-    ///
-    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
-    ///
-    ///
-    /// Available since API-level: 12
-    #[cfg(feature = "api-12")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-    pub const HITRACE_FLAG_D2D_TP_INFO: HiTrace_Flag = HiTrace_Flag(64);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl ::core::ops::BitOr<HiTrace_Flag> for HiTrace_Flag {
     type Output = Self;
     #[inline]
@@ -355,6 +237,92 @@ impl ::core::ops::BitAndAssign for HiTrace_Flag {
         self.0 &= rhs.0;
     }
 }
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
+impl HiTrace_Flag {
+    /// Default flag.
+    ///
+    ///
+    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
+    ///
+    ///
+    /// Available since API-level: 12
+    #[cfg(feature = "api-12")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
+    pub const HITRACE_FLAG_DEFAULT: HiTrace_Flag = HiTrace_Flag(0);
+    /// Both synchronous and asynchronous calls are traced. By default, only synchronous calls are traced.
+    ///
+    ///
+    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
+    ///
+    ///
+    /// Available since API-level: 12
+    #[cfg(feature = "api-12")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
+    pub const HITRACE_FLAG_INCLUDE_ASYNC: HiTrace_Flag = HiTrace_Flag(1);
+    /// No spans are created. By default, spans are created.
+    ///
+    ///
+    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
+    ///
+    ///
+    /// Available since API-level: 12
+    #[cfg(feature = "api-12")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
+    pub const HITRACE_FLAG_DONOT_CREATE_SPAN: HiTrace_Flag = HiTrace_Flag(2);
+    /// Trace points are automatically added to spans. By default, no trace point is added.
+    ///
+    ///
+    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
+    ///
+    ///
+    /// Available since API-level: 12
+    #[cfg(feature = "api-12")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
+    pub const HITRACE_FLAG_TP_INFO: HiTrace_Flag = HiTrace_Flag(4);
+    /// Information about the start and end of the trace task is not printed. By default, information about the
+    /// start and end of the trace task is printed.
+    ///
+    ///
+    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
+    ///
+    ///
+    /// Available since API-level: 12
+    #[cfg(feature = "api-12")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
+    pub const HITRACE_FLAG_NO_BE_INFO: HiTrace_Flag = HiTrace_Flag(8);
+    /// The ID is not added to the log. By default, the ID is added to the log.
+    ///
+    ///
+    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
+    ///
+    ///
+    /// Available since API-level: 12
+    #[cfg(feature = "api-12")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
+    pub const HITRACE_FLAG_DONOT_ENABLE_LOG: HiTrace_Flag = HiTrace_Flag(16);
+    /// Tracing is triggered by faults.
+    ///
+    ///
+    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
+    ///
+    ///
+    /// Available since API-level: 12
+    #[cfg(feature = "api-12")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
+    pub const HITRACE_FLAG_FAULT_TRIGGER: HiTrace_Flag = HiTrace_Flag(32);
+    /// Trace points are added only for call chain trace between devices.
+    /// By default, device-to-device trace points are not added.
+    ///
+    ///
+    /// Required System Capabilities: SystemCapability.HiviewDFX.HiTrace
+    ///
+    ///
+    /// Available since API-level: 12
+    #[cfg(feature = "api-12")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
+    pub const HITRACE_FLAG_D2D_TP_INFO: HiTrace_Flag = HiTrace_Flag(64);
+}
 #[repr(transparent)]
 /// Enumerates the HiTrace flags.
 ///
@@ -367,8 +335,6 @@ impl ::core::ops::BitAndAssign for HiTrace_Flag {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct HiTrace_Flag(pub ::core::ffi::c_uint);
-#[repr(u32)]
-#[non_exhaustive]
 /// Enumerates the HiTrace trace point types.
 ///
 ///
@@ -379,6 +345,8 @@ pub struct HiTrace_Flag(pub ::core::ffi::c_uint);
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[repr(u32)]
+#[non_exhaustive]
 pub enum HiTrace_Tracepoint_Type {
     /// CS trace point.
     ///
@@ -444,10 +412,6 @@ impl HiTrace_Communication_Mode {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const HITRACE_CM_DEFAULT: HiTrace_Communication_Mode = HiTrace_Communication_Mode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTrace_Communication_Mode {
     /// Inter-thread communication.
     ///
     ///
@@ -458,10 +422,6 @@ impl HiTrace_Communication_Mode {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const HITRACE_CM_THREAD: HiTrace_Communication_Mode = HiTrace_Communication_Mode(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTrace_Communication_Mode {
     /// Inter-process communication.
     ///
     ///
@@ -472,10 +432,6 @@ impl HiTrace_Communication_Mode {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const HITRACE_CM_PROCESS: HiTrace_Communication_Mode = HiTrace_Communication_Mode(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl HiTrace_Communication_Mode {
     /// Inter-device communication.
     ///
     ///

--- a/components/inputmethod/src/types/types_ffi.rs
+++ b/components/inputmethod/src/types/types_ffi.rs
@@ -9,16 +9,8 @@
 impl InputMethod_KeyboardStatus {
     /// The keyboard status is none.
     pub const IME_KEYBOARD_STATUS_NONE: InputMethod_KeyboardStatus = InputMethod_KeyboardStatus(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_KeyboardStatus {
     /// The keyboard status is hide.
     pub const IME_KEYBOARD_STATUS_HIDE: InputMethod_KeyboardStatus = InputMethod_KeyboardStatus(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_KeyboardStatus {
     /// The keyboard status is show.
     pub const IME_KEYBOARD_STATUS_SHOW: InputMethod_KeyboardStatus = InputMethod_KeyboardStatus(2);
 }
@@ -36,52 +28,20 @@ pub struct InputMethod_KeyboardStatus(pub ::core::ffi::c_uint);
 impl InputMethod_EnterKeyType {
     /// The enter key type is UNSPECIFIED.
     pub const IME_ENTER_KEY_UNSPECIFIED: InputMethod_EnterKeyType = InputMethod_EnterKeyType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_EnterKeyType {
     /// The enter key type is NONE.
     pub const IME_ENTER_KEY_NONE: InputMethod_EnterKeyType = InputMethod_EnterKeyType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_EnterKeyType {
     /// The enter key type is GO.
     pub const IME_ENTER_KEY_GO: InputMethod_EnterKeyType = InputMethod_EnterKeyType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_EnterKeyType {
     /// The enter key type is SEARCH.
     pub const IME_ENTER_KEY_SEARCH: InputMethod_EnterKeyType = InputMethod_EnterKeyType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_EnterKeyType {
     /// The enter key type is SEND.
     pub const IME_ENTER_KEY_SEND: InputMethod_EnterKeyType = InputMethod_EnterKeyType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_EnterKeyType {
     /// The enter key type is NEXT.
     pub const IME_ENTER_KEY_NEXT: InputMethod_EnterKeyType = InputMethod_EnterKeyType(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_EnterKeyType {
     /// The enter key type is DONE.
     pub const IME_ENTER_KEY_DONE: InputMethod_EnterKeyType = InputMethod_EnterKeyType(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_EnterKeyType {
     /// The enter key type is PREVIOUS.
     pub const IME_ENTER_KEY_PREVIOUS: InputMethod_EnterKeyType = InputMethod_EnterKeyType(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_EnterKeyType {
     /// The enter key type is NEWLINE.
     pub const IME_ENTER_KEY_NEWLINE: InputMethod_EnterKeyType = InputMethod_EnterKeyType(8);
 }
@@ -99,28 +59,12 @@ pub struct InputMethod_EnterKeyType(pub ::core::ffi::c_uint);
 impl InputMethod_Direction {
     /// The direction is NONE.
     pub const IME_DIRECTION_NONE: InputMethod_Direction = InputMethod_Direction(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_Direction {
     /// The direction is UP.
     pub const IME_DIRECTION_UP: InputMethod_Direction = InputMethod_Direction(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_Direction {
     /// The direction is DOWN.
     pub const IME_DIRECTION_DOWN: InputMethod_Direction = InputMethod_Direction(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_Direction {
     /// The direction is LEFT.
     pub const IME_DIRECTION_LEFT: InputMethod_Direction = InputMethod_Direction(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_Direction {
     /// The direction is RIGHT.
     pub const IME_DIRECTION_RIGHT: InputMethod_Direction = InputMethod_Direction(4);
 }
@@ -138,22 +82,10 @@ pub struct InputMethod_Direction(pub ::core::ffi::c_uint);
 impl InputMethod_ExtendAction {
     /// Select all text.
     pub const IME_EXTEND_ACTION_SELECT_ALL: InputMethod_ExtendAction = InputMethod_ExtendAction(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_ExtendAction {
     /// Cut selected text.
     pub const IME_EXTEND_ACTION_CUT: InputMethod_ExtendAction = InputMethod_ExtendAction(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_ExtendAction {
     /// Copy selected text.
     pub const IME_EXTEND_ACTION_COPY: InputMethod_ExtendAction = InputMethod_ExtendAction(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_ExtendAction {
     /// Paste from paste board.
     pub const IME_EXTEND_ACTION_PASTE: InputMethod_ExtendAction = InputMethod_ExtendAction(5);
 }
@@ -171,90 +103,38 @@ pub struct InputMethod_ExtendAction(pub ::core::ffi::c_uint);
 impl InputMethod_TextInputType {
     /// The text input type is NONE.
     pub const IME_TEXT_INPUT_TYPE_NONE: InputMethod_TextInputType = InputMethod_TextInputType(-1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is TEXT.
     pub const IME_TEXT_INPUT_TYPE_TEXT: InputMethod_TextInputType = InputMethod_TextInputType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is MULTILINE.
     pub const IME_TEXT_INPUT_TYPE_MULTILINE: InputMethod_TextInputType =
         InputMethod_TextInputType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is NUMBER.
     pub const IME_TEXT_INPUT_TYPE_NUMBER: InputMethod_TextInputType = InputMethod_TextInputType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is PHONE.
     pub const IME_TEXT_INPUT_TYPE_PHONE: InputMethod_TextInputType = InputMethod_TextInputType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is DATETIME.
     pub const IME_TEXT_INPUT_TYPE_DATETIME: InputMethod_TextInputType =
         InputMethod_TextInputType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is EMAIL ADDRESS.
     pub const IME_TEXT_INPUT_TYPE_EMAIL_ADDRESS: InputMethod_TextInputType =
         InputMethod_TextInputType(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is URL.
     pub const IME_TEXT_INPUT_TYPE_URL: InputMethod_TextInputType = InputMethod_TextInputType(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is VISIBLE PASSWORD.
     pub const IME_TEXT_INPUT_TYPE_VISIBLE_PASSWORD: InputMethod_TextInputType =
         InputMethod_TextInputType(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is NUMBER PASSWORD.
     pub const IME_TEXT_INPUT_TYPE_NUMBER_PASSWORD: InputMethod_TextInputType =
         InputMethod_TextInputType(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is SCREEN LOCK PASSWORD.
     pub const IME_TEXT_INPUT_TYPE_SCREEN_LOCK_PASSWORD: InputMethod_TextInputType =
         InputMethod_TextInputType(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is USER NAME.
     pub const IME_TEXT_INPUT_TYPE_USER_NAME: InputMethod_TextInputType =
         InputMethod_TextInputType(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is NEW PASSWORD.
     pub const IME_TEXT_INPUT_TYPE_NEW_PASSWORD: InputMethod_TextInputType =
         InputMethod_TextInputType(11);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_TextInputType {
     /// The text input type is NUMBER DECIMAL.
     pub const IME_TEXT_INPUT_TYPE_NUMBER_DECIMAL: InputMethod_TextInputType =
         InputMethod_TextInputType(12);
@@ -274,24 +154,12 @@ impl InputMethod_CommandValueType {
     /// Value type is NONE.
     pub const IME_COMMAND_VALUE_TYPE_NONE: InputMethod_CommandValueType =
         InputMethod_CommandValueType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_CommandValueType {
     /// Value type is STRING.
     pub const IME_COMMAND_VALUE_TYPE_STRING: InputMethod_CommandValueType =
         InputMethod_CommandValueType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_CommandValueType {
     /// Value type is BOOL.
     pub const IME_COMMAND_VALUE_TYPE_BOOL: InputMethod_CommandValueType =
         InputMethod_CommandValueType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethod_CommandValueType {
     /// Value type is INT32.
     pub const IME_COMMAND_VALUE_TYPE_INT32: InputMethod_CommandValueType =
         InputMethod_CommandValueType(3);
@@ -305,91 +173,47 @@ impl InputMethod_CommandValueType {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct InputMethod_CommandValueType(pub ::core::ffi::c_uint);
+pub type InputMethodResult = Result<(), InputMethodErrorCode>;
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl InputMethodErrorCode {
     /// The error code when error is undefined.
     pub const UNDEFINED: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(1).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethodErrorCode {
     /// The error code when parameter check failed.
     pub const PARAMCHECK: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(401).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethodErrorCode {
     /// The error code when the bundle manager error.
     pub const PACKAGEMANAGER: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(12800001).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethodErrorCode {
     /// The error code when input method engine error.
     pub const IMENGINE: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(12800002).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethodErrorCode {
     /// The error code when input method client error.
     pub const IMCLIENT: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(12800003).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethodErrorCode {
     /// The error code when configuration persistence error.
     pub const CONFIG_PERSIST: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(12800005).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethodErrorCode {
     /// The error code when input method controller error.
     pub const CONTROLLER: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(12800006).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethodErrorCode {
     /// The error code when input method setting error.
     pub const SETTINGS: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(12800007).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethodErrorCode {
     /// The error code when input method manager service error.
     pub const IMMS: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(12800008).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethodErrorCode {
     /// The error code when input method client detached.
     pub const DETACHED: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(12800009).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethodErrorCode {
     /// The error code when unexpected null pointer.
     pub const NULL_POINTER: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(12802000).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputMethodErrorCode {
     /// The error code when query failed.
     pub const QUERY_FAILED: InputMethodErrorCode =
         InputMethodErrorCode(const { core::num::NonZero::new(12802001).unwrap() });
 }
-pub type InputMethodResult = Result<(), InputMethodErrorCode>;
 #[repr(transparent)]
 /// The value type of command data.
 ///

--- a/components/multimedia/image_framework/src/native_image/image_common/image_common_ffi.rs
+++ b/components/multimedia/image_framework/src/native_image/image_common/image_common_ffi.rs
@@ -71,110 +71,42 @@ pub type Image_MimeType = Image_String;
 impl ImageResult {
     /// operation success
     pub const SUCCESS: ImageResult = ImageResult(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// invalid parameter
     pub const BAD_PARAMETER: ImageResult = ImageResult(401);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// unsupported mime type
     pub const UNSUPPORTED_MIME_TYPE: ImageResult = ImageResult(7600101);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// unknown mime type
     pub const UNKNOWN_MIME_TYPE: ImageResult = ImageResult(7600102);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// too large data or image
     pub const TOO_LARGE: ImageResult = ImageResult(7600103);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// DMA memory does not exist
     pub const DMA_NOT_EXIST: ImageResult = ImageResult(7600173);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// DMA operation failed
     pub const DMA_OPERATION_FAILED: ImageResult = ImageResult(7600174);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// unsupported operations
     pub const UNSUPPORTED_OPERATION: ImageResult = ImageResult(7600201);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// unsupported metadata
     pub const UNSUPPORTED_METADATA: ImageResult = ImageResult(7600202);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// unsupported conversion
     pub const UNSUPPORTED_CONVERSION: ImageResult = ImageResult(7600203);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// invalid region
     pub const INVALID_REGION: ImageResult = ImageResult(7600204);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// unsupported memory format
     ///
     /// Available since API-level: 13
     #[cfg(feature = "api-13")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
     pub const UNSUPPORTED_MEMORY_FORMAT: ImageResult = ImageResult(7600205);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// failed to allocate memory
     pub const ALLOC_FAILED: ImageResult = ImageResult(7600301);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// memory copy failed
     pub const COPY_FAILED: ImageResult = ImageResult(7600302);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// unknown error
     pub const UNKNOWN_ERROR: ImageResult = ImageResult(7600901);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// decode data source exception
     pub const BAD_SOURCE: ImageResult = ImageResult(7700101);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// decode failed
     pub const DECODE_FAILED: ImageResult = ImageResult(7700301);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl ImageResult {
     /// encode failed
     pub const ENCODE_FAILED: ImageResult = ImageResult(7800301);
 }
@@ -191,10 +123,6 @@ pub struct ImageResult(pub ::core::ffi::c_uint);
 #[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
 impl Image_MetadataType {
     pub const EXIF_METADATA: Image_MetadataType = Image_MetadataType(1);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl Image_MetadataType {
     pub const FRAGMENT_METADATA: Image_MetadataType = Image_MetadataType(2);
 }
 #[repr(transparent)]

--- a/components/multimedia/image_framework/src/native_image/image_packer/image_packer_ffi.rs
+++ b/components/multimedia/image_framework/src/native_image/image_packer/image_packer_ffi.rs
@@ -35,10 +35,6 @@ pub struct OH_PackingOptions {
 impl IMAGE_PACKER_DYNAMIC_RANGE {
     pub const IMAGE_PACKER_DYNAMIC_RANGE_AUTO: IMAGE_PACKER_DYNAMIC_RANGE =
         IMAGE_PACKER_DYNAMIC_RANGE(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl IMAGE_PACKER_DYNAMIC_RANGE {
     pub const IMAGE_PACKER_DYNAMIC_RANGE_SDR: IMAGE_PACKER_DYNAMIC_RANGE =
         IMAGE_PACKER_DYNAMIC_RANGE(1);
 }

--- a/components/multimedia/image_framework/src/native_image/image_source/image_source_ffi.rs
+++ b/components/multimedia/image_framework/src/native_image/image_source/image_source_ffi.rs
@@ -36,15 +36,7 @@ pub struct OH_DecodingOptionsForPicture {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl IMAGE_DYNAMIC_RANGE {
     pub const IMAGE_DYNAMIC_RANGE_AUTO: IMAGE_DYNAMIC_RANGE = IMAGE_DYNAMIC_RANGE(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl IMAGE_DYNAMIC_RANGE {
     pub const IMAGE_DYNAMIC_RANGE_SDR: IMAGE_DYNAMIC_RANGE = IMAGE_DYNAMIC_RANGE(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl IMAGE_DYNAMIC_RANGE {
     pub const IMAGE_DYNAMIC_RANGE_HDR: IMAGE_DYNAMIC_RANGE = IMAGE_DYNAMIC_RANGE(2);
 }
 #[repr(transparent)]

--- a/components/multimedia/image_framework/src/native_image/picture/picture_ffi.rs
+++ b/components/multimedia/image_framework/src/native_image/picture/picture_ffi.rs
@@ -44,28 +44,12 @@ pub struct OH_AuxiliaryPictureInfo {
 impl Image_AuxiliaryPictureType {
     pub const AUXILIARY_PICTURE_TYPE_GAINMAP: Image_AuxiliaryPictureType =
         Image_AuxiliaryPictureType(1);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl Image_AuxiliaryPictureType {
     pub const AUXILIARY_PICTURE_TYPE_DEPTH_MAP: Image_AuxiliaryPictureType =
         Image_AuxiliaryPictureType(2);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl Image_AuxiliaryPictureType {
     pub const AUXILIARY_PICTURE_TYPE_UNREFOCUS_MAP: Image_AuxiliaryPictureType =
         Image_AuxiliaryPictureType(3);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl Image_AuxiliaryPictureType {
     pub const AUXILIARY_PICTURE_TYPE_LINEAR_MAP: Image_AuxiliaryPictureType =
         Image_AuxiliaryPictureType(4);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl Image_AuxiliaryPictureType {
     pub const AUXILIARY_PICTURE_TYPE_FRAGMENT_MAP: Image_AuxiliaryPictureType =
         Image_AuxiliaryPictureType(5);
 }

--- a/components/multimedia/image_framework/src/native_image/pixelmap/pixelmap_ffi.rs
+++ b/components/multimedia/image_framework/src/native_image/pixelmap/pixelmap_ffi.rs
@@ -12,20 +12,8 @@ use ohos_sys_opaque_types::{
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl PIXELMAP_ALPHA_TYPE {
     pub const PIXELMAP_ALPHA_TYPE_UNKNOWN: PIXELMAP_ALPHA_TYPE = PIXELMAP_ALPHA_TYPE(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl PIXELMAP_ALPHA_TYPE {
     pub const PIXELMAP_ALPHA_TYPE_OPAQUE: PIXELMAP_ALPHA_TYPE = PIXELMAP_ALPHA_TYPE(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl PIXELMAP_ALPHA_TYPE {
     pub const PIXELMAP_ALPHA_TYPE_PREMULTIPLIED: PIXELMAP_ALPHA_TYPE = PIXELMAP_ALPHA_TYPE(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl PIXELMAP_ALPHA_TYPE {
     pub const PIXELMAP_ALPHA_TYPE_UNPREMULTIPLIED: PIXELMAP_ALPHA_TYPE = PIXELMAP_ALPHA_TYPE(3);
 }
 #[repr(transparent)]
@@ -39,38 +27,16 @@ impl PIXELMAP_ALPHA_TYPE {
 pub struct PIXELMAP_ALPHA_TYPE(pub ::core::ffi::c_uint);
 impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_UNKNOWN: PIXEL_FORMAT = PIXEL_FORMAT(0);
-}
-impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_RGB_565: PIXEL_FORMAT = PIXEL_FORMAT(2);
-}
-impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_RGBA_8888: PIXEL_FORMAT = PIXEL_FORMAT(3);
-}
-impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_BGRA_8888: PIXEL_FORMAT = PIXEL_FORMAT(4);
-}
-impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_RGB_888: PIXEL_FORMAT = PIXEL_FORMAT(5);
-}
-impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_ALPHA_8: PIXEL_FORMAT = PIXEL_FORMAT(6);
-}
-impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_RGBA_F16: PIXEL_FORMAT = PIXEL_FORMAT(7);
-}
-impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_NV21: PIXEL_FORMAT = PIXEL_FORMAT(8);
-}
-impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_NV12: PIXEL_FORMAT = PIXEL_FORMAT(9);
-}
-impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_RGBA_1010102: PIXEL_FORMAT = PIXEL_FORMAT(10);
-}
-impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_YCBCR_P010: PIXEL_FORMAT = PIXEL_FORMAT(11);
-}
-impl PIXEL_FORMAT {
     pub const PIXEL_FORMAT_YCRCB_P010: PIXEL_FORMAT = PIXEL_FORMAT(12);
 }
 #[repr(transparent)]
@@ -82,24 +48,12 @@ impl OH_PixelmapNative_AntiAliasingLevel {
     /// Nearest-neighbor interpolation algorithm
     pub const OH_PixelmapNative_AntiAliasing_NONE: OH_PixelmapNative_AntiAliasingLevel =
         OH_PixelmapNative_AntiAliasingLevel(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_PixelmapNative_AntiAliasingLevel {
     /// Bilinear interpolation algorithm
     pub const OH_PixelmapNative_AntiAliasing_LOW: OH_PixelmapNative_AntiAliasingLevel =
         OH_PixelmapNative_AntiAliasingLevel(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_PixelmapNative_AntiAliasingLevel {
     /// Bilinear interpolation algorithm with mipmap linear filtering
     pub const OH_PixelmapNative_AntiAliasing_MEDIUM: OH_PixelmapNative_AntiAliasingLevel =
         OH_PixelmapNative_AntiAliasingLevel(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_PixelmapNative_AntiAliasingLevel {
     /// Cubic interpolation algorithm
     pub const OH_PixelmapNative_AntiAliasing_HIGH: OH_PixelmapNative_AntiAliasingLevel =
         OH_PixelmapNative_AntiAliasingLevel(3);
@@ -118,22 +72,10 @@ pub struct OH_PixelmapNative_AntiAliasingLevel(pub ::core::ffi::c_uint);
 impl OH_Pixelmap_HdrMetadataKey {
     /// Indicate the types of metadata that image needs to use.
     pub const HDR_METADATA_TYPE: OH_Pixelmap_HdrMetadataKey = OH_Pixelmap_HdrMetadataKey(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Pixelmap_HdrMetadataKey {
     /// Static metadata key.
     pub const HDR_STATIC_METADATA: OH_Pixelmap_HdrMetadataKey = OH_Pixelmap_HdrMetadataKey(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Pixelmap_HdrMetadataKey {
     /// Dynamic metadata key.
     pub const HDR_DYNAMIC_METADATA: OH_Pixelmap_HdrMetadataKey = OH_Pixelmap_HdrMetadataKey(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Pixelmap_HdrMetadataKey {
     /// Gainmap metadata key.
     pub const HDR_GAINMAP_METADATA: OH_Pixelmap_HdrMetadataKey = OH_Pixelmap_HdrMetadataKey(3);
 }
@@ -151,23 +93,11 @@ pub struct OH_Pixelmap_HdrMetadataKey(pub ::core::ffi::c_uint);
 impl OH_Pixelmap_HdrMetadataType {
     /// No metadata.
     pub const HDR_METADATA_TYPE_NONE: OH_Pixelmap_HdrMetadataType = OH_Pixelmap_HdrMetadataType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Pixelmap_HdrMetadataType {
     /// Indicates that metadata will be used for the base image.
     pub const HDR_METADATA_TYPE_BASE: OH_Pixelmap_HdrMetadataType = OH_Pixelmap_HdrMetadataType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Pixelmap_HdrMetadataType {
     /// Indicates that metadata will be used for the gainmap image.
     pub const HDR_METADATA_TYPE_GAINMAP: OH_Pixelmap_HdrMetadataType =
         OH_Pixelmap_HdrMetadataType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_Pixelmap_HdrMetadataType {
     /// Indicates that metadata will be used for the alternate image.
     pub const HDR_METADATA_TYPE_ALTERNATE: OH_Pixelmap_HdrMetadataType =
         OH_Pixelmap_HdrMetadataType(3);

--- a/components/multimodal-input/src/axis_type/axis_type_ffi.rs
+++ b/components/multimodal-input/src/axis_type/axis_type_ffi.rs
@@ -14,10 +14,6 @@ impl InputEvent_AxisType {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const AXIS_TYPE_UNKNOWN: InputEvent_AxisType = InputEvent_AxisType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputEvent_AxisType {
     /// Indicates the vertical scroll axis. When you scroll the mouse wheel or make certain gestures on the touchpad,
     /// the status of the vertical scroll axis changes.
     ///
@@ -26,10 +22,6 @@ impl InputEvent_AxisType {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const AXIS_TYPE_SCROLL_VERTICAL: InputEvent_AxisType = InputEvent_AxisType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputEvent_AxisType {
     /// Indicates the horizontal scroll axis.
     /// When you scroll the mouse wheel or make certain gestures on the touchpad,
     /// the status of the horizontal scroll axis changes.
@@ -39,10 +31,6 @@ impl InputEvent_AxisType {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const AXIS_TYPE_SCROLL_HORIZONTAL: InputEvent_AxisType = InputEvent_AxisType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputEvent_AxisType {
     /// Indicates the pinch axis, which is used to describe a pinch gesture on the touchscreen or touchpad.
     ///
     ///
@@ -50,10 +38,6 @@ impl InputEvent_AxisType {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const AXIS_TYPE_PINCH: InputEvent_AxisType = InputEvent_AxisType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputEvent_AxisType {
     /// Indicates the rotate axis, which is used to describe a rotate gesture on the touchpad.
     ///
     ///
@@ -81,10 +65,6 @@ impl InputEvent_AxisEventType {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const AXIS_EVENT_TYPE_PINCH: InputEvent_AxisEventType = InputEvent_AxisEventType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputEvent_AxisEventType {
     /// Enumerates scroll axis events.
     /// The axis value can be AXIS_TYPE_SCROLL_VERTICAL or AXIS_TYPE_SCROLL_HORIZONTAL.
     /// Wherein, the value of AXIS_TYPE_SCROLL_HORIZONTAL is 0 for a mouse wheel event.
@@ -114,10 +94,6 @@ impl InputEvent_AxisAction {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const AXIS_ACTION_CANCEL: InputEvent_AxisAction = InputEvent_AxisAction(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputEvent_AxisAction {
     /// Start action for the axis input event.
     ///
     ///
@@ -125,10 +101,6 @@ impl InputEvent_AxisAction {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const AXIS_ACTION_BEGIN: InputEvent_AxisAction = InputEvent_AxisAction(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputEvent_AxisAction {
     /// Update action for the axis input event.
     ///
     ///
@@ -136,10 +108,6 @@ impl InputEvent_AxisAction {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const AXIS_ACTION_UPDATE: InputEvent_AxisAction = InputEvent_AxisAction(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputEvent_AxisAction {
     /// End action for the axis input event.
     ///
     ///

--- a/components/multimodal-input/src/input_manager/input_manager_ffi.rs
+++ b/components/multimodal-input/src/input_manager/input_manager_ffi.rs
@@ -10,28 +10,12 @@ use crate::axis_type::{InputEvent_AxisAction, InputEvent_AxisEventType, InputEve
 impl Input_KeyStateAction {
     /// Default
     pub const KEY_DEFAULT: Input_KeyStateAction = Input_KeyStateAction(-1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_KeyStateAction {
     /// Pressing of a key
     pub const KEY_PRESSED: Input_KeyStateAction = Input_KeyStateAction(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_KeyStateAction {
     /// Release of a key
     pub const KEY_RELEASED: Input_KeyStateAction = Input_KeyStateAction(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_KeyStateAction {
     /// Key switch enabled
     pub const KEY_SWITCH_ON: Input_KeyStateAction = Input_KeyStateAction(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_KeyStateAction {
     /// Key switch disabled
     pub const KEY_SWITCH_OFF: Input_KeyStateAction = Input_KeyStateAction(3);
 }
@@ -49,16 +33,8 @@ pub struct Input_KeyStateAction(pub ::core::ffi::c_int);
 impl Input_KeyEventAction {
     /// Cancellation of a key action.
     pub const KEY_ACTION_CANCEL: Input_KeyEventAction = Input_KeyEventAction(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_KeyEventAction {
     /// Pressing of a key.
     pub const KEY_ACTION_DOWN: Input_KeyEventAction = Input_KeyEventAction(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_KeyEventAction {
     /// Release of a key.
     pub const KEY_ACTION_UP: Input_KeyEventAction = Input_KeyEventAction(2);
 }
@@ -76,40 +52,16 @@ pub struct Input_KeyEventAction(pub ::core::ffi::c_uint);
 impl Input_MouseEventAction {
     /// Cancel.
     pub const MOUSE_ACTION_CANCEL: Input_MouseEventAction = Input_MouseEventAction(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_MouseEventAction {
     /// Moving of the mouse pointer.
     pub const MOUSE_ACTION_MOVE: Input_MouseEventAction = Input_MouseEventAction(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_MouseEventAction {
     /// Pressing down of the mouse.
     pub const MOUSE_ACTION_BUTTON_DOWN: Input_MouseEventAction = Input_MouseEventAction(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_MouseEventAction {
     /// Lifting of the mouse button.
     pub const MOUSE_ACTION_BUTTON_UP: Input_MouseEventAction = Input_MouseEventAction(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_MouseEventAction {
     /// Beginning of the mouse axis event
     pub const MOUSE_ACTION_AXIS_BEGIN: Input_MouseEventAction = Input_MouseEventAction(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_MouseEventAction {
     /// Updating of the mouse axis event
     pub const MOUSE_ACTION_AXIS_UPDATE: Input_MouseEventAction = Input_MouseEventAction(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_MouseEventAction {
     /// End of the mouse axis event
     pub const MOUSE_ACTION_AXIS_END: Input_MouseEventAction = Input_MouseEventAction(6);
 }
@@ -127,10 +79,6 @@ pub struct Input_MouseEventAction(pub ::core::ffi::c_uint);
 impl InputEvent_MouseAxis {
     /// Vertical scroll axis
     pub const MOUSE_AXIS_SCROLL_VERTICAL: InputEvent_MouseAxis = InputEvent_MouseAxis(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputEvent_MouseAxis {
     /// Horizontal scroll axis
     pub const MOUSE_AXIS_SCROLL_HORIZONTAL: InputEvent_MouseAxis = InputEvent_MouseAxis(1);
 }
@@ -148,34 +96,14 @@ pub struct InputEvent_MouseAxis(pub ::core::ffi::c_uint);
 impl Input_MouseEventButton {
     /// Invalid button
     pub const MOUSE_BUTTON_NONE: Input_MouseEventButton = Input_MouseEventButton(-1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_MouseEventButton {
     /// Left button on the mouse.
     pub const MOUSE_BUTTON_LEFT: Input_MouseEventButton = Input_MouseEventButton(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_MouseEventButton {
     /// Middle button on the mouse.
     pub const MOUSE_BUTTON_MIDDLE: Input_MouseEventButton = Input_MouseEventButton(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_MouseEventButton {
     /// Right button on the mouse.
     pub const MOUSE_BUTTON_RIGHT: Input_MouseEventButton = Input_MouseEventButton(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_MouseEventButton {
     /// Forward button on the mouse.
     pub const MOUSE_BUTTON_FORWARD: Input_MouseEventButton = Input_MouseEventButton(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_MouseEventButton {
     /// Back button on the mouse.
     pub const MOUSE_BUTTON_BACK: Input_MouseEventButton = Input_MouseEventButton(4);
 }
@@ -193,22 +121,10 @@ pub struct Input_MouseEventButton(pub ::core::ffi::c_int);
 impl Input_TouchEventAction {
     /// Touch cancelled.
     pub const TOUCH_ACTION_CANCEL: Input_TouchEventAction = Input_TouchEventAction(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_TouchEventAction {
     /// Touch pressed.
     pub const TOUCH_ACTION_DOWN: Input_TouchEventAction = Input_TouchEventAction(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_TouchEventAction {
     /// Touch moved.
     pub const TOUCH_ACTION_MOVE: Input_TouchEventAction = Input_TouchEventAction(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl Input_TouchEventAction {
     /// Touch lifted.
     pub const TOUCH_ACTION_UP: Input_TouchEventAction = Input_TouchEventAction(3);
 }
@@ -226,34 +142,14 @@ pub struct Input_TouchEventAction(pub ::core::ffi::c_uint);
 impl Input_KeyboardType {
     /// Keyboard without keys
     pub const KEYBOARD_TYPE_NONE: Input_KeyboardType = Input_KeyboardType(0);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl Input_KeyboardType {
     /// Keyboard with unknown keys
     pub const KEYBOARD_TYPE_UNKNOWN: Input_KeyboardType = Input_KeyboardType(1);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl Input_KeyboardType {
     /// Full keyboard
     pub const KEYBOARD_TYPE_ALPHABETIC: Input_KeyboardType = Input_KeyboardType(2);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl Input_KeyboardType {
     /// Digital keyboard
     pub const KEYBOARD_TYPE_DIGITAL: Input_KeyboardType = Input_KeyboardType(3);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl Input_KeyboardType {
     /// Stylus
     pub const KEYBOARD_TYPE_STYLUS: Input_KeyboardType = Input_KeyboardType(4);
-}
-#[cfg(feature = "api-13")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
-impl Input_KeyboardType {
     /// Remote control
     pub const KEYBOARD_TYPE_REMOTE_CONTROL: Input_KeyboardType = Input_KeyboardType(5);
 }
@@ -277,10 +173,6 @@ impl InputEvent_SourceType {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const SOURCE_TYPE_MOUSE: InputEvent_SourceType = InputEvent_SourceType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputEvent_SourceType {
     /// Indicates that the input source generates a touchscreen multi-touch event.
     ///
     ///
@@ -288,10 +180,6 @@ impl InputEvent_SourceType {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const SOURCE_TYPE_TOUCHSCREEN: InputEvent_SourceType = InputEvent_SourceType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputEvent_SourceType {
     /// Indicates that the input source generates a touchpad multi-touch event.
     ///
     ///
@@ -333,51 +221,28 @@ pub struct Input_AxisEvent {
 pub struct Input_Hotkey {
     _unused: [u8; 0],
 }
+pub type Input_Result = Result<(), InputErrorCode>;
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl InputErrorCode {
     /// Permission verification failed
     pub const PERMISSION_DENIED: InputErrorCode =
         InputErrorCode(const { core::num::NonZero::new(201).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputErrorCode {
     /// Non-system application
     pub const NOT_SYSTEM_APPLICATION: InputErrorCode =
         InputErrorCode(const { core::num::NonZero::new(202).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputErrorCode {
     /// Parameter check failed
     pub const PARAMETER_ERROR: InputErrorCode =
         InputErrorCode(const { core::num::NonZero::new(401).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputErrorCode {
     /// Device not support
     pub const DEVICE_NOT_SUPPORTED: InputErrorCode =
         InputErrorCode(const { core::num::NonZero::new(801).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputErrorCode {
     /// Service error
     pub const SERVICE_EXCEPTION: InputErrorCode =
         InputErrorCode(const { core::num::NonZero::new(3800001).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputErrorCode {
     /// Interceptor repeatedly created for an application
     pub const REPEAT_INTERCEPTOR: InputErrorCode =
         InputErrorCode(const { core::num::NonZero::new(4200001).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputErrorCode {
     /// Already occupied by the system
     ///
     /// Available since API-level: 14
@@ -385,10 +250,6 @@ impl InputErrorCode {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
     pub const OCCUPIED_BY_SYSTEM: InputErrorCode =
         InputErrorCode(const { core::num::NonZero::new(4200002).unwrap() });
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl InputErrorCode {
     /// Already occupied by the other
     ///
     /// Available since API-level: 14
@@ -397,7 +258,6 @@ impl InputErrorCode {
     pub const OCCUPIED_BY_OTHER: InputErrorCode =
         InputErrorCode(const { core::num::NonZero::new(4200003).unwrap() });
 }
-pub type Input_Result = Result<(), InputErrorCode>;
 #[repr(transparent)]
 /// Enumerates error codes.
 ///

--- a/components/multimodal-input/src/key_code/key_code_ffi.rs
+++ b/components/multimodal-input/src/key_code/key_code_ffi.rs
@@ -4,7 +4,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-#[repr(i32)]
 /// Enumerated values of OpenHarmony key code.
 ///
 ///
@@ -12,6 +11,7 @@
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[repr(i32)]
 pub enum Input_KeyCode {
     /// Unknown key
     KEYCODE_UNKNOWN = -1,

--- a/components/xcomponent/src/xcomponent_ffi.rs
+++ b/components/xcomponent/src/xcomponent_ffi.rs
@@ -10,1004 +10,346 @@ pub const OH_NATIVE_XCOMPONENT_OBJ: &::core::ffi::CStr = c"__NATIVE_XCOMPONENT_O
 pub const OH_NATIVE_XCOMPONENT_MAX_TOUCH_POINTS_NUMBER: u32 = 10;
 impl OH_NativeXComponent_KeyCode {
     pub const KEY_UNKNOWN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(-1);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_FN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(0);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_HOME: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(1);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BACK: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_PLAY_PAUSE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(10);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_STOP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(11);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_NEXT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(12);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_PREVIOUS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(13);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_REWIND: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(14);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_FAST_FORWARD: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(15);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_VOLUME_UP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(16);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_VOLUME_DOWN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(17);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_POWER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(18);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CAMERA: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(19);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_VOLUME_MUTE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(22);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MUTE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(23);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BRIGHTNESS_UP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(40);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BRIGHTNESS_DOWN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(41);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_0: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2000);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_1: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2001);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_2: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2002);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_3: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2003);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_4: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2004);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_5: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2005);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_6: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2006);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_7: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2007);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_8: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2008);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_9: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2009);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_STAR: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2010);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_POUND: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2011);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DPAD_UP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2012);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DPAD_DOWN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2013);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DPAD_LEFT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2014);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DPAD_RIGHT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2015);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DPAD_CENTER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2016);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_A: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2017);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_B: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2018);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_C: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2019);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_D: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2020);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_E: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2021);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2022);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_G: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2023);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_H: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2024);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_I: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2025);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_J: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2026);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_K: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2027);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_L: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2028);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_M: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2029);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_N: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2030);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_O: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2031);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_P: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2032);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_Q: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2033);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_R: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2034);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_S: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2035);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_T: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2036);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_U: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2037);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_V: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2038);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_W: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2039);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_X: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2040);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_Y: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2041);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_Z: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2042);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_COMMA: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2043);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PERIOD: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2044);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ALT_LEFT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2045);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ALT_RIGHT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2046);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SHIFT_LEFT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2047);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SHIFT_RIGHT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2048);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_TAB: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2049);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SPACE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2050);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SYM: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2051);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_EXPLORER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2052);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ENVELOPE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2053);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ENTER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2054);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DEL: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2055);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_GRAVE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2056);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MINUS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2057);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_EQUALS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2058);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_LEFT_BRACKET: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2059);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_RIGHT_BRACKET: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2060);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BACKSLASH: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2061);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SEMICOLON: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2062);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_APOSTROPHE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2063);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SLASH: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2064);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_AT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2065);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PLUS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2066);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MENU: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2067);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PAGE_UP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2068);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PAGE_DOWN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2069);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ESCAPE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2070);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_FORWARD_DEL: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2071);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CTRL_LEFT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2072);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CTRL_RIGHT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2073);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CAPS_LOCK: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2074);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SCROLL_LOCK: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2075);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_META_LEFT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2076);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_META_RIGHT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2077);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_FUNCTION: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2078);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SYSRQ: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2079);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BREAK: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2080);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MOVE_HOME: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2081);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MOVE_END: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2082);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_INSERT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2083);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_FORWARD: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2084);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_PLAY: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2085);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_PAUSE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2086);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_CLOSE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2087);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_EJECT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2088);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_RECORD: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2089);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F1: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2090);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F2: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2091);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F3: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2092);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F4: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2093);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F5: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2094);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F6: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2095);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F7: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2096);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F8: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2097);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F9: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2098);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F10: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2099);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F11: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2100);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F12: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2101);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUM_LOCK: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2102);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_0: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2103);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_1: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2104);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_2: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2105);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_3: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2106);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_4: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2107);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_5: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2108);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_6: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2109);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_7: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2110);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_8: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2111);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_9: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2112);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_DIVIDE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2113);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_MULTIPLY: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2114);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_SUBTRACT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2115);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_ADD: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2116);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_DOT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2117);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_COMMA: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2118);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_ENTER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2119);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_EQUALS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2120);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_LEFT_PAREN: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2121);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_RIGHT_PAREN: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2122);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_VIRTUAL_MULTITASK: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2210);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SLEEP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2600);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ZENKAKU_HANKAKU: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2601);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_102ND: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2602);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_RO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2603);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KATAKANA: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2604);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_HIRAGANA: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2605);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_HENKAN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2606);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KATAKANA_HIRAGANA: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2607);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MUHENKAN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2608);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_LINEFEED: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2609);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MACRO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2610);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NUMPAD_PLUSMINUS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2611);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SCALE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2612);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_HANGUEL: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2613);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_HANJA: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2614);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_YEN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2615);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_STOP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2616);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_AGAIN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2617);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PROPS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2618);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_UNDO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2619);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_COPY: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2620);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_OPEN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2621);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PASTE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2622);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_FIND: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2623);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CUT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2624);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_HELP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2625);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CALC: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2626);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_FILE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2627);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BOOKMARKS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2628);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NEXT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2629);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PLAYPAUSE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2630);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PREVIOUS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2631);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_STOPCD: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2632);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CONFIG: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2634);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_REFRESH: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2635);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_EXIT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2636);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_EDIT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2637);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SCROLLUP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2638);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SCROLLDOWN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2639);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NEW: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2640);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_REDO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2641);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CLOSE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2642);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PLAY: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2643);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BASSBOOST: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2644);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PRINT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2645);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CHAT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2646);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_FINANCE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2647);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CANCEL: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2648);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KBDILLUM_TOGGLE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2649);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KBDILLUM_DOWN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2650);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KBDILLUM_UP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2651);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SEND: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2652);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_REPLY: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2653);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_FORWARDMAIL: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2654);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SAVE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2655);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DOCUMENTS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2656);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_VIDEO_NEXT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2657);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_VIDEO_PREV: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2658);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BRIGHTNESS_CYCLE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2659);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BRIGHTNESS_ZERO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2660);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DISPLAY_OFF: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2661);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BTN_MISC: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2662);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_GOTO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2663);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_INFO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2664);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PROGRAM: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2665);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PVR: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2666);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SUBTITLE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2667);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_FULL_SCREEN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2668);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KEYBOARD: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2669);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ASPECT_RATIO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2670);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PC: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2671);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_TV: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2672);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_TV2: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2673);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_VCR: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2674);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_VCR2: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2675);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SAT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2676);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CD: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2677);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_TAPE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2678);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_TUNER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2679);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PLAYER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2680);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DVD: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2681);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_AUDIO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2682);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_VIDEO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2683);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEMO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2684);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CALENDAR: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2685);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_RED: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2686);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_GREEN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2687);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_YELLOW: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2688);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BLUE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2689);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CHANNELUP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2690);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CHANNELDOWN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2691);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_LAST: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2692);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_RESTART: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2693);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SLOW: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2694);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SHUFFLE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2695);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_VIDEOPHONE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2696);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_GAMES: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2697);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ZOOMIN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2698);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ZOOMOUT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2699);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ZOOMRESET: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2700);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_WORDPROCESSOR: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2701);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_EDITOR: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2702);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SPREADSHEET: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2703);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_GRAPHICSEDITOR: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2704);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PRESENTATION: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2705);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DATABASE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2706);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_NEWS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2707);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_VOICEMAIL: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2708);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ADDRESSBOOK: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2709);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MESSENGER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2710);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BRIGHTNESS_TOGGLE: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2711);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SPELLCHECK: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2712);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_COFFEE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2713);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MEDIA_REPEAT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2714);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_IMAGES: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2715);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BUTTONCONFIG: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2716);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_TASKMANAGER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2717);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_JOURNAL: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2718);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CONTROLPANEL: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2719);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_APPSELECT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2720);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SCREENSAVER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2721);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ASSISTANT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2722);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KBD_LAYOUT_NEXT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2723);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BRIGHTNESS_MIN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2724);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BRIGHTNESS_MAX: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2725);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KBDINPUTASSIST_PREV: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2726);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KBDINPUTASSIST_NEXT: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2727);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KBDINPUTASSIST_PREVGROUP: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2728);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KBDINPUTASSIST_NEXTGROUP: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2729);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KBDINPUTASSIST_ACCEPT: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2730);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_KBDINPUTASSIST_CANCEL: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2731);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_FRONT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2800);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SETUP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2801);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_WAKEUP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2802);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SENDFILE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2803);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DELETEFILE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2804);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_XFER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2805);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PROG1: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2806);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PROG2: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2807);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MSDOS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2808);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SCREENLOCK: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2809);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DIRECTION_ROTATE_DISPLAY: OH_NativeXComponent_KeyCode =
         OH_NativeXComponent_KeyCode(2810);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CYCLEWINDOWS: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2811);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_COMPUTER: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2812);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_EJECTCLOSECD: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2813);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ISO: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2814);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_MOVE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2815);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F13: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2816);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F14: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2817);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F15: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2818);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F16: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2819);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F17: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2820);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F18: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2821);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F19: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2822);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F20: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2823);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F21: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2824);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F22: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2825);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F23: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2826);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_F24: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2827);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PROG3: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2828);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_PROG4: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2829);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_DASHBOARD: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2830);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SUSPEND: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2831);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_HP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2832);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SOUND: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2833);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_QUESTION: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2834);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CONNECT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2836);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SPORT: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2837);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SHOP: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2838);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_ALTERASE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2839);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_SWITCHVIDEOMODE: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2841);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BATTERY: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2842);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BLUETOOTH: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2843);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_WLAN: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2844);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_UWB: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2845);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_WWAN_WIMAX: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2846);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_RFKILL: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(2847);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_CHANNEL: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(3001);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BTN_0: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(3100);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BTN_1: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(3101);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BTN_2: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(3102);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BTN_3: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(3103);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BTN_4: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(3104);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BTN_5: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(3105);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BTN_6: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(3106);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BTN_7: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(3107);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BTN_8: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(3108);
-}
-impl OH_NativeXComponent_KeyCode {
     pub const KEY_BTN_9: OH_NativeXComponent_KeyCode = OH_NativeXComponent_KeyCode(3109);
 }
 #[repr(transparent)]
@@ -1022,12 +364,8 @@ pub struct OH_NativeXComponent_KeyCode(pub ::core::ffi::c_int);
 impl OH_NativeXComponent_KeyAction {
     pub const OH_NATIVEXCOMPONENT_KEY_ACTION_UNKNOWN: OH_NativeXComponent_KeyAction =
         OH_NativeXComponent_KeyAction(-1);
-}
-impl OH_NativeXComponent_KeyAction {
     pub const OH_NATIVEXCOMPONENT_KEY_ACTION_DOWN: OH_NativeXComponent_KeyAction =
         OH_NativeXComponent_KeyAction(0);
-}
-impl OH_NativeXComponent_KeyAction {
     pub const OH_NATIVEXCOMPONENT_KEY_ACTION_UP: OH_NativeXComponent_KeyAction =
         OH_NativeXComponent_KeyAction(1);
 }
@@ -1046,23 +384,15 @@ impl OH_NativeXComponent_TouchEventType {
     /// Trigger a touch event when a finger is pressed.
     pub const OH_NATIVEXCOMPONENT_DOWN: OH_NativeXComponent_TouchEventType =
         OH_NativeXComponent_TouchEventType(0);
-}
-impl OH_NativeXComponent_TouchEventType {
     /// Trigger a touch event when a finger is lifted.
     pub const OH_NATIVEXCOMPONENT_UP: OH_NativeXComponent_TouchEventType =
         OH_NativeXComponent_TouchEventType(1);
-}
-impl OH_NativeXComponent_TouchEventType {
     /// Trigger a touch event when a finger moves on the screen in pressed state.
     pub const OH_NATIVEXCOMPONENT_MOVE: OH_NativeXComponent_TouchEventType =
         OH_NativeXComponent_TouchEventType(2);
-}
-impl OH_NativeXComponent_TouchEventType {
     /// Trigger an event when a touch event is canceled.
     pub const OH_NATIVEXCOMPONENT_CANCEL: OH_NativeXComponent_TouchEventType =
         OH_NativeXComponent_TouchEventType(3);
-}
-impl OH_NativeXComponent_TouchEventType {
     /// Invalid touch type.
     pub const OH_NATIVEXCOMPONENT_UNKNOWN: OH_NativeXComponent_TouchEventType =
         OH_NativeXComponent_TouchEventType(4);
@@ -1074,43 +404,27 @@ impl OH_NativeXComponent_TouchPointToolType {
     /// Indicates invalid tool type.
     pub const OH_NATIVEXCOMPONENT_TOOL_TYPE_UNKNOWN: OH_NativeXComponent_TouchPointToolType =
         OH_NativeXComponent_TouchPointToolType(0);
-}
-impl OH_NativeXComponent_TouchPointToolType {
     /// Indicates a finger.
     pub const OH_NATIVEXCOMPONENT_TOOL_TYPE_FINGER: OH_NativeXComponent_TouchPointToolType =
         OH_NativeXComponent_TouchPointToolType(1);
-}
-impl OH_NativeXComponent_TouchPointToolType {
     /// Indicates a stylus.
     pub const OH_NATIVEXCOMPONENT_TOOL_TYPE_PEN: OH_NativeXComponent_TouchPointToolType =
         OH_NativeXComponent_TouchPointToolType(2);
-}
-impl OH_NativeXComponent_TouchPointToolType {
     /// Indicates a eraser.
     pub const OH_NATIVEXCOMPONENT_TOOL_TYPE_RUBBER: OH_NativeXComponent_TouchPointToolType =
         OH_NativeXComponent_TouchPointToolType(3);
-}
-impl OH_NativeXComponent_TouchPointToolType {
     /// Indicates a brush.
     pub const OH_NATIVEXCOMPONENT_TOOL_TYPE_BRUSH: OH_NativeXComponent_TouchPointToolType =
         OH_NativeXComponent_TouchPointToolType(4);
-}
-impl OH_NativeXComponent_TouchPointToolType {
     /// Indicates a pencil.
     pub const OH_NATIVEXCOMPONENT_TOOL_TYPE_PENCIL: OH_NativeXComponent_TouchPointToolType =
         OH_NativeXComponent_TouchPointToolType(5);
-}
-impl OH_NativeXComponent_TouchPointToolType {
     /// Indicates a brush.
     pub const OH_NATIVEXCOMPONENT_TOOL_TYPE_AIRBRUSH: OH_NativeXComponent_TouchPointToolType =
         OH_NativeXComponent_TouchPointToolType(6);
-}
-impl OH_NativeXComponent_TouchPointToolType {
     /// Indicates a mouse.
     pub const OH_NATIVEXCOMPONENT_TOOL_TYPE_MOUSE: OH_NativeXComponent_TouchPointToolType =
         OH_NativeXComponent_TouchPointToolType(7);
-}
-impl OH_NativeXComponent_TouchPointToolType {
     /// Indicates a lens.
     pub const OH_NATIVEXCOMPONENT_TOOL_TYPE_LENS: OH_NativeXComponent_TouchPointToolType =
         OH_NativeXComponent_TouchPointToolType(8);
@@ -1128,28 +442,18 @@ impl OH_NativeXComponent_EventSourceType {
     /// Indicates an unknown input source type.
     pub const OH_NATIVEXCOMPONENT_SOURCE_TYPE_UNKNOWN: OH_NativeXComponent_EventSourceType =
         OH_NativeXComponent_EventSourceType(0);
-}
-impl OH_NativeXComponent_EventSourceType {
     /// Indicates that the input source generates a mouse multi-touch event.
     pub const OH_NATIVEXCOMPONENT_SOURCE_TYPE_MOUSE: OH_NativeXComponent_EventSourceType =
         OH_NativeXComponent_EventSourceType(1);
-}
-impl OH_NativeXComponent_EventSourceType {
     /// Indicates that the input source generates a touchscreen multi-touch event.
     pub const OH_NATIVEXCOMPONENT_SOURCE_TYPE_TOUCHSCREEN: OH_NativeXComponent_EventSourceType =
         OH_NativeXComponent_EventSourceType(2);
-}
-impl OH_NativeXComponent_EventSourceType {
     /// Indicates that the input source generates a touchpad multi-touch event.
     pub const OH_NATIVEXCOMPONENT_SOURCE_TYPE_TOUCHPAD: OH_NativeXComponent_EventSourceType =
         OH_NativeXComponent_EventSourceType(3);
-}
-impl OH_NativeXComponent_EventSourceType {
     /// Indicates that the input source generates a joystick multi-touch event.
     pub const OH_NATIVEXCOMPONENT_SOURCE_TYPE_JOYSTICK: OH_NativeXComponent_EventSourceType =
         OH_NativeXComponent_EventSourceType(4);
-}
-impl OH_NativeXComponent_EventSourceType {
     /// Indicates that the input source generates a keyboard event.
     ///
     ///
@@ -1171,16 +475,10 @@ pub struct OH_NativeXComponent_EventSourceType(pub ::core::ffi::c_uint);
 impl OH_NativeXComponent_MouseEventAction {
     pub const OH_NATIVEXCOMPONENT_MOUSE_NONE: OH_NativeXComponent_MouseEventAction =
         OH_NativeXComponent_MouseEventAction(0);
-}
-impl OH_NativeXComponent_MouseEventAction {
     pub const OH_NATIVEXCOMPONENT_MOUSE_PRESS: OH_NativeXComponent_MouseEventAction =
         OH_NativeXComponent_MouseEventAction(1);
-}
-impl OH_NativeXComponent_MouseEventAction {
     pub const OH_NATIVEXCOMPONENT_MOUSE_RELEASE: OH_NativeXComponent_MouseEventAction =
         OH_NativeXComponent_MouseEventAction(2);
-}
-impl OH_NativeXComponent_MouseEventAction {
     pub const OH_NATIVEXCOMPONENT_MOUSE_MOVE: OH_NativeXComponent_MouseEventAction =
         OH_NativeXComponent_MouseEventAction(3);
 }
@@ -1196,24 +494,14 @@ pub struct OH_NativeXComponent_MouseEventAction(pub ::core::ffi::c_uint);
 impl OH_NativeXComponent_MouseEventButton {
     pub const OH_NATIVEXCOMPONENT_NONE_BUTTON: OH_NativeXComponent_MouseEventButton =
         OH_NativeXComponent_MouseEventButton(0);
-}
-impl OH_NativeXComponent_MouseEventButton {
     pub const OH_NATIVEXCOMPONENT_LEFT_BUTTON: OH_NativeXComponent_MouseEventButton =
         OH_NativeXComponent_MouseEventButton(1);
-}
-impl OH_NativeXComponent_MouseEventButton {
     pub const OH_NATIVEXCOMPONENT_RIGHT_BUTTON: OH_NativeXComponent_MouseEventButton =
         OH_NativeXComponent_MouseEventButton(2);
-}
-impl OH_NativeXComponent_MouseEventButton {
     pub const OH_NATIVEXCOMPONENT_MIDDLE_BUTTON: OH_NativeXComponent_MouseEventButton =
         OH_NativeXComponent_MouseEventButton(4);
-}
-impl OH_NativeXComponent_MouseEventButton {
     pub const OH_NATIVEXCOMPONENT_BACK_BUTTON: OH_NativeXComponent_MouseEventButton =
         OH_NativeXComponent_MouseEventButton(8);
-}
-impl OH_NativeXComponent_MouseEventButton {
     pub const OH_NATIVEXCOMPONENT_FORWARD_BUTTON: OH_NativeXComponent_MouseEventButton =
         OH_NativeXComponent_MouseEventButton(16);
 }
@@ -1229,40 +517,22 @@ pub struct OH_NativeXComponent_MouseEventButton(pub ::core::ffi::c_uint);
 impl OH_NativeXComponent_TouchEvent_SourceTool {
     pub const OH_NATIVEXCOMPONENT_SOURCETOOL_UNKNOWN: OH_NativeXComponent_TouchEvent_SourceTool =
         OH_NativeXComponent_TouchEvent_SourceTool(0);
-}
-impl OH_NativeXComponent_TouchEvent_SourceTool {
     pub const OH_NATIVEXCOMPONENT_SOURCETOOL_FINGER: OH_NativeXComponent_TouchEvent_SourceTool =
         OH_NativeXComponent_TouchEvent_SourceTool(1);
-}
-impl OH_NativeXComponent_TouchEvent_SourceTool {
     pub const OH_NATIVEXCOMPONENT_SOURCETOOL_PEN: OH_NativeXComponent_TouchEvent_SourceTool =
         OH_NativeXComponent_TouchEvent_SourceTool(2);
-}
-impl OH_NativeXComponent_TouchEvent_SourceTool {
     pub const OH_NATIVEXCOMPONENT_SOURCETOOL_RUBBER: OH_NativeXComponent_TouchEvent_SourceTool =
         OH_NativeXComponent_TouchEvent_SourceTool(3);
-}
-impl OH_NativeXComponent_TouchEvent_SourceTool {
     pub const OH_NATIVEXCOMPONENT_SOURCETOOL_BRUSH: OH_NativeXComponent_TouchEvent_SourceTool =
         OH_NativeXComponent_TouchEvent_SourceTool(4);
-}
-impl OH_NativeXComponent_TouchEvent_SourceTool {
     pub const OH_NATIVEXCOMPONENT_SOURCETOOL_PENCIL: OH_NativeXComponent_TouchEvent_SourceTool =
         OH_NativeXComponent_TouchEvent_SourceTool(5);
-}
-impl OH_NativeXComponent_TouchEvent_SourceTool {
     pub const OH_NATIVEXCOMPONENT_SOURCETOOL_AIRBRUSH: OH_NativeXComponent_TouchEvent_SourceTool =
         OH_NativeXComponent_TouchEvent_SourceTool(6);
-}
-impl OH_NativeXComponent_TouchEvent_SourceTool {
     pub const OH_NATIVEXCOMPONENT_SOURCETOOL_MOUSE: OH_NativeXComponent_TouchEvent_SourceTool =
         OH_NativeXComponent_TouchEvent_SourceTool(7);
-}
-impl OH_NativeXComponent_TouchEvent_SourceTool {
     pub const OH_NATIVEXCOMPONENT_SOURCETOOL_LENS: OH_NativeXComponent_TouchEvent_SourceTool =
         OH_NativeXComponent_TouchEvent_SourceTool(8);
-}
-impl OH_NativeXComponent_TouchEvent_SourceTool {
     pub const OH_NATIVEXCOMPONENT_SOURCETOOL_TOUCHPAD: OH_NativeXComponent_TouchEvent_SourceTool =
         OH_NativeXComponent_TouchEvent_SourceTool(9);
 }

--- a/scripts/generator/src/dir_conf.rs
+++ b/scripts/generator/src/dir_conf.rs
@@ -28,20 +28,6 @@ fn strip_prefix(input: &str, prefix: &str) -> String {
     }
 }
 
-/// Defines the prefixes that each enum has (which we probably want to remove)
-static ENUM_PREFIX_MAP: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
-    HashMap::from([
-        ("Image_ErrorCode", "IMAGE_"),
-        ("OH_Drawing_ErrorCode", "OH_DRAWING_ERROR_"),
-        ("ArkUI_DragResult", "ARKUI_DRAG_RESULT_"),
-        ("ArkUI_GestureInterruptResult", "GESTURE_INTERRUPT_RESULT_"),
-        ("ArkUI_ErrorCode", "ARKUI_ERROR_CODE_"),
-        ("InputMethod_ErrorCode", "IME_ERR_"),
-        ("Input_Result", "INPUT_"),
-        ("OH_Drawing_FontConfigInfoErrorCode", "ERROR_FONT_CONFIG_INFO_")
-    ])
-});
-
 struct ResultEnumParseCallbacks {
     /// fn item_name(&self, original_item_name: &str) -> Option<String> {
     rename_item: Box<dyn Fn(&str) -> Option<String>>,
@@ -69,22 +55,6 @@ impl Debug for ResultEnumParseCallbacks {
 impl bindgen::callbacks::ParseCallbacks for ResultEnumParseCallbacks {
     fn item_name(&self, original_item_name: &str) -> Option<String> {
         (self.rename_item)(original_item_name)
-    }
-    fn enum_variant_name(
-        &self,
-        enum_name: Option<&str>,
-        original_variant_name: &str,
-        _variant_value: EnumVariantValue,
-    ) -> Option<String> {
-        let enum_name = enum_name?.trim_start_matches("enum ");
-        if let Some(custom_rename) = &self.rename_enum_variant {
-            (custom_rename)(enum_name, original_variant_name)
-        } else {
-            ENUM_PREFIX_MAP
-                .get(enum_name)
-                .and_then(|prefix| original_variant_name.strip_prefix(prefix))
-                .map(|stripped| stripped.to_string())
-        }
     }
 }
 

--- a/scripts/generator/src/enum_prefix.rs
+++ b/scripts/generator/src/enum_prefix.rs
@@ -1,0 +1,16 @@
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// Defines the prefixes that each enum has (which we probably want to remove)
+pub(crate) static ENUM_PREFIX_MAP: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
+    HashMap::from([
+        ("Image_ErrorCode", "IMAGE_"),
+        ("OH_Drawing_ErrorCode", "OH_DRAWING_ERROR_"),
+        ("ArkUI_DragResult", "ARKUI_DRAG_RESULT_"),
+        ("ArkUI_GestureInterruptResult", "GESTURE_INTERRUPT_RESULT_"),
+        ("ArkUI_ErrorCode", "ARKUI_ERROR_CODE_"),
+        ("InputMethod_ErrorCode", "IME_ERR_"),
+        ("Input_Result", "INPUT_"),
+        ("OH_Drawing_FontConfigInfoErrorCode", "ERROR_FONT_CONFIG_INFO_")
+    ])
+});

--- a/scripts/generator/src/main.rs
+++ b/scripts/generator/src/main.rs
@@ -147,8 +147,7 @@ impl bindgen::callbacks::ParseCallbacks for DoxygenCommentCb {
         }
         // Replace manual linebreaks in doxygen with double linebreaks for markdown.
         let comment = comment.replace("\\n", "\n");
-        Some(doxygen_rs::transform(&comment))
-        // None
+        Some(doxygen_rs::transform(&comment.trim_end_matches("\n")))
     }
 
     fn parse_comments_for_attributes(&self, comment: &str) -> Vec<CodeGenAttributes> {

--- a/src/napi/napi_ffi.rs
+++ b/src/napi/napi_ffi.rs
@@ -11,14 +11,8 @@ pub const NAPI_AUTO_LENGTH: i32 = -1;
 pub const NAPI_MODULE_VERSION: u32 = 1;
 impl napi_qos_t {
     pub const napi_qos_background: napi_qos_t = napi_qos_t(0);
-}
-impl napi_qos_t {
     pub const napi_qos_utility: napi_qos_t = napi_qos_t(1);
-}
-impl napi_qos_t {
     pub const napi_qos_default: napi_qos_t = napi_qos_t(2);
-}
-impl napi_qos_t {
     pub const napi_qos_user_initiated: napi_qos_t = napi_qos_t(3);
 }
 #[repr(transparent)]
@@ -30,10 +24,6 @@ impl napi_event_mode {
     /// In this mode, the current asynchronous thread will be blocked and events of native event loop will
     /// be processed.
     pub const napi_event_mode_default: napi_event_mode = napi_event_mode(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl napi_event_mode {
     /// In this mode, the current asynchronous thread will not be blocked. If there are events in the event loop,
     /// only one event will be processed and then the event loop will stop. If there are no events in the loop,
     /// the event loop will stop immediately.
@@ -53,22 +43,10 @@ pub struct napi_event_mode(pub ::core::ffi::c_uint);
 impl napi_task_priority {
     /// The immediate priority tasks should be promptly processed whenever feasible.
     pub const napi_priority_immediate: napi_task_priority = napi_task_priority(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl napi_task_priority {
     /// The high priority tasks, as sorted by their handle time, should be prioritized over tasks with low priority.
     pub const napi_priority_high: napi_task_priority = napi_task_priority(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl napi_task_priority {
     /// The low priority tasks, as sorted by their handle time, should be processed before idle priority tasks.
     pub const napi_priority_low: napi_task_priority = napi_task_priority(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl napi_task_priority {
     /// The idle priority tasks should be processed immediately only if there are no other priority tasks.
     pub const napi_priority_idle: napi_task_priority = napi_task_priority(3);
 }
@@ -109,23 +87,11 @@ pub struct napi_deferred__ {
 pub type napi_deferred = *mut napi_deferred__;
 impl napi_property_attributes {
     pub const napi_default: napi_property_attributes = napi_property_attributes(0);
-}
-impl napi_property_attributes {
     pub const napi_writable: napi_property_attributes = napi_property_attributes(1);
-}
-impl napi_property_attributes {
     pub const napi_enumerable: napi_property_attributes = napi_property_attributes(2);
-}
-impl napi_property_attributes {
     pub const napi_configurable: napi_property_attributes = napi_property_attributes(4);
-}
-impl napi_property_attributes {
     pub const napi_static: napi_property_attributes = napi_property_attributes(1024);
-}
-impl napi_property_attributes {
     pub const napi_default_method: napi_property_attributes = napi_property_attributes(5);
-}
-impl napi_property_attributes {
     pub const napi_default_jsproperty: napi_property_attributes = napi_property_attributes(7);
 }
 #[repr(transparent)]
@@ -133,32 +99,14 @@ impl napi_property_attributes {
 pub struct napi_property_attributes(pub ::core::ffi::c_uint);
 impl napi_valuetype {
     pub const napi_undefined: napi_valuetype = napi_valuetype(0);
-}
-impl napi_valuetype {
     pub const napi_null: napi_valuetype = napi_valuetype(1);
-}
-impl napi_valuetype {
     pub const napi_boolean: napi_valuetype = napi_valuetype(2);
-}
-impl napi_valuetype {
     pub const napi_number: napi_valuetype = napi_valuetype(3);
-}
-impl napi_valuetype {
     pub const napi_string: napi_valuetype = napi_valuetype(4);
-}
-impl napi_valuetype {
     pub const napi_symbol: napi_valuetype = napi_valuetype(5);
-}
-impl napi_valuetype {
     pub const napi_object: napi_valuetype = napi_valuetype(6);
-}
-impl napi_valuetype {
     pub const napi_function: napi_valuetype = napi_valuetype(7);
-}
-impl napi_valuetype {
     pub const napi_external: napi_valuetype = napi_valuetype(8);
-}
-impl napi_valuetype {
     pub const napi_bigint: napi_valuetype = napi_valuetype(9);
 }
 #[repr(transparent)]
@@ -166,35 +114,15 @@ impl napi_valuetype {
 pub struct napi_valuetype(pub ::core::ffi::c_uint);
 impl napi_typedarray_type {
     pub const napi_int8_array: napi_typedarray_type = napi_typedarray_type(0);
-}
-impl napi_typedarray_type {
     pub const napi_uint8_array: napi_typedarray_type = napi_typedarray_type(1);
-}
-impl napi_typedarray_type {
     pub const napi_uint8_clamped_array: napi_typedarray_type = napi_typedarray_type(2);
-}
-impl napi_typedarray_type {
     pub const napi_int16_array: napi_typedarray_type = napi_typedarray_type(3);
-}
-impl napi_typedarray_type {
     pub const napi_uint16_array: napi_typedarray_type = napi_typedarray_type(4);
-}
-impl napi_typedarray_type {
     pub const napi_int32_array: napi_typedarray_type = napi_typedarray_type(5);
-}
-impl napi_typedarray_type {
     pub const napi_uint32_array: napi_typedarray_type = napi_typedarray_type(6);
-}
-impl napi_typedarray_type {
     pub const napi_float32_array: napi_typedarray_type = napi_typedarray_type(7);
-}
-impl napi_typedarray_type {
     pub const napi_float64_array: napi_typedarray_type = napi_typedarray_type(8);
-}
-impl napi_typedarray_type {
     pub const napi_bigint64_array: napi_typedarray_type = napi_typedarray_type(9);
-}
-impl napi_typedarray_type {
     pub const napi_biguint64_array: napi_typedarray_type = napi_typedarray_type(10);
 }
 #[repr(transparent)]
@@ -202,77 +130,29 @@ impl napi_typedarray_type {
 pub struct napi_typedarray_type(pub ::core::ffi::c_uint);
 impl napi_status {
     pub const napi_ok: napi_status = napi_status(0);
-}
-impl napi_status {
     pub const napi_invalid_arg: napi_status = napi_status(1);
-}
-impl napi_status {
     pub const napi_object_expected: napi_status = napi_status(2);
-}
-impl napi_status {
     pub const napi_string_expected: napi_status = napi_status(3);
-}
-impl napi_status {
     pub const napi_name_expected: napi_status = napi_status(4);
-}
-impl napi_status {
     pub const napi_function_expected: napi_status = napi_status(5);
-}
-impl napi_status {
     pub const napi_number_expected: napi_status = napi_status(6);
-}
-impl napi_status {
     pub const napi_boolean_expected: napi_status = napi_status(7);
-}
-impl napi_status {
     pub const napi_array_expected: napi_status = napi_status(8);
-}
-impl napi_status {
     pub const napi_generic_failure: napi_status = napi_status(9);
-}
-impl napi_status {
     pub const napi_pending_exception: napi_status = napi_status(10);
-}
-impl napi_status {
     pub const napi_cancelled: napi_status = napi_status(11);
-}
-impl napi_status {
     pub const napi_escape_called_twice: napi_status = napi_status(12);
-}
-impl napi_status {
     pub const napi_handle_scope_mismatch: napi_status = napi_status(13);
-}
-impl napi_status {
     pub const napi_callback_scope_mismatch: napi_status = napi_status(14);
-}
-impl napi_status {
     pub const napi_queue_full: napi_status = napi_status(15);
-}
-impl napi_status {
     pub const napi_closing: napi_status = napi_status(16);
-}
-impl napi_status {
     pub const napi_bigint_expected: napi_status = napi_status(17);
-}
-impl napi_status {
     pub const napi_date_expected: napi_status = napi_status(18);
-}
-impl napi_status {
     pub const napi_arraybuffer_expected: napi_status = napi_status(19);
-}
-impl napi_status {
     pub const napi_detachable_arraybuffer_expected: napi_status = napi_status(20);
-}
-impl napi_status {
     pub const napi_would_deadlock: napi_status = napi_status(21);
-}
-impl napi_status {
     pub const napi_create_ark_runtime_too_many_envs: napi_status = napi_status(22);
-}
-impl napi_status {
     pub const napi_create_ark_runtime_only_one_env_per_thread: napi_status = napi_status(23);
-}
-impl napi_status {
     pub const napi_destroy_ark_runtime_env_not_exist: napi_status = napi_status(24);
 }
 #[repr(transparent)]
@@ -309,8 +189,6 @@ pub struct napi_extended_error_info {
 }
 impl napi_key_collection_mode {
     pub const napi_key_include_prototypes: napi_key_collection_mode = napi_key_collection_mode(0);
-}
-impl napi_key_collection_mode {
     pub const napi_key_own_only: napi_key_collection_mode = napi_key_collection_mode(1);
 }
 #[repr(transparent)]
@@ -318,20 +196,10 @@ impl napi_key_collection_mode {
 pub struct napi_key_collection_mode(pub ::core::ffi::c_uint);
 impl napi_key_filter {
     pub const napi_key_all_properties: napi_key_filter = napi_key_filter(0);
-}
-impl napi_key_filter {
     pub const napi_key_writable: napi_key_filter = napi_key_filter(1);
-}
-impl napi_key_filter {
     pub const napi_key_enumerable: napi_key_filter = napi_key_filter(2);
-}
-impl napi_key_filter {
     pub const napi_key_configurable: napi_key_filter = napi_key_filter(4);
-}
-impl napi_key_filter {
     pub const napi_key_skip_strings: napi_key_filter = napi_key_filter(8);
-}
-impl napi_key_filter {
     pub const napi_key_skip_symbols: napi_key_filter = napi_key_filter(16);
 }
 #[repr(transparent)]
@@ -339,8 +207,6 @@ impl napi_key_filter {
 pub struct napi_key_filter(pub ::core::ffi::c_uint);
 impl napi_key_conversion {
     pub const napi_key_keep_numbers: napi_key_conversion = napi_key_conversion(0);
-}
-impl napi_key_conversion {
     pub const napi_key_numbers_to_strings: napi_key_conversion = napi_key_conversion(1);
 }
 #[repr(transparent)]
@@ -375,8 +241,6 @@ pub type napi_threadsafe_function = *mut napi_threadsafe_function__;
 impl napi_threadsafe_function_release_mode {
     pub const napi_tsfn_release: napi_threadsafe_function_release_mode =
         napi_threadsafe_function_release_mode(0);
-}
-impl napi_threadsafe_function_release_mode {
     pub const napi_tsfn_abort: napi_threadsafe_function_release_mode =
         napi_threadsafe_function_release_mode(1);
 }
@@ -386,8 +250,6 @@ pub struct napi_threadsafe_function_release_mode(pub ::core::ffi::c_uint);
 impl napi_threadsafe_function_call_mode {
     pub const napi_tsfn_nonblocking: napi_threadsafe_function_call_mode =
         napi_threadsafe_function_call_mode(0);
-}
-impl napi_threadsafe_function_call_mode {
     pub const napi_tsfn_blocking: napi_threadsafe_function_call_mode =
         napi_threadsafe_function_call_mode(1);
 }

--- a/src/native_buffer/native_buffer_ffi.rs
+++ b/src/native_buffer/native_buffer_ffi.rs
@@ -7,120 +7,58 @@ use ohos_sys_opaque_types::{OHNativeWindowBuffer, OH_NativeBuffer};
 
 impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_NONE: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(0);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_BT601_EBU_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(1);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_BT601_SMPTE_C_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(2);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_BT709_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(3);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_BT2020_HLG_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(4);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_BT2020_PQ_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(5);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_BT601_EBU_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(6);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_BT601_SMPTE_C_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(7);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_BT709_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(8);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_BT2020_HLG_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(9);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_BT2020_PQ_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(10);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_SRGB_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(11);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_P3_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(12);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_P3_HLG_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(13);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_P3_PQ_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(14);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_ADOBERGB_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(15);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_SRGB_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(16);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_P3_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(17);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_P3_HLG_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(18);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_P3_PQ_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(19);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_ADOBERGB_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(20);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_LINEAR_SRGB: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(21);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_LINEAR_BT709: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(22);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_LINEAR_P3: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(23);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_LINEAR_BT2020: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(24);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_DISPLAY_SRGB: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(25);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_DISPLAY_P3_SRGB: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(26);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_DISPLAY_P3_HLG: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(27);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_DISPLAY_P3_PQ: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(28);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_DISPLAY_BT2020_SRGB: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(29);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_DISPLAY_BT2020_HLG: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(30);
-}
-impl OH_NativeBuffer_ColorSpace {
     pub const OH_COLORSPACE_DISPLAY_BT2020_PQ: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(31);
 }
@@ -129,14 +67,8 @@ impl OH_NativeBuffer_ColorSpace {
 pub struct OH_NativeBuffer_ColorSpace(pub ::core::ffi::c_uint);
 impl OH_NativeBuffer_MetadataType {
     pub const OH_VIDEO_HDR_HLG: OH_NativeBuffer_MetadataType = OH_NativeBuffer_MetadataType(0);
-}
-impl OH_NativeBuffer_MetadataType {
     pub const OH_VIDEO_HDR_HDR10: OH_NativeBuffer_MetadataType = OH_NativeBuffer_MetadataType(1);
-}
-impl OH_NativeBuffer_MetadataType {
     pub const OH_VIDEO_HDR_VIVID: OH_NativeBuffer_MetadataType = OH_NativeBuffer_MetadataType(2);
-}
-impl OH_NativeBuffer_MetadataType {
     pub const OH_VIDEO_NONE: OH_NativeBuffer_MetadataType = OH_NativeBuffer_MetadataType(-1);
 }
 #[repr(transparent)]
@@ -172,45 +104,12 @@ pub struct OH_NativeBuffer_StaticMetadata {
 }
 impl OH_NativeBuffer_MetadataKey {
     pub const OH_HDR_METADATA_TYPE: OH_NativeBuffer_MetadataKey = OH_NativeBuffer_MetadataKey(0);
-}
-impl OH_NativeBuffer_MetadataKey {
     pub const OH_HDR_STATIC_METADATA: OH_NativeBuffer_MetadataKey = OH_NativeBuffer_MetadataKey(1);
-}
-impl OH_NativeBuffer_MetadataKey {
     pub const OH_HDR_DYNAMIC_METADATA: OH_NativeBuffer_MetadataKey = OH_NativeBuffer_MetadataKey(2);
 }
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct OH_NativeBuffer_MetadataKey(pub ::core::ffi::c_uint);
-impl OH_NativeBuffer_Usage {
-    pub const NATIVEBUFFER_USAGE_CPU_READ: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(1);
-}
-impl OH_NativeBuffer_Usage {
-    /// < CPU read buffer */
-    pub const NATIVEBUFFER_USAGE_CPU_WRITE: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(2);
-}
-impl OH_NativeBuffer_Usage {
-    /// < CPU write memory */
-    pub const NATIVEBUFFER_USAGE_MEM_DMA: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(8);
-}
-impl OH_NativeBuffer_Usage {
-    /// < Direct memory access (DMA) buffer */
-    pub const NATIVEBUFFER_USAGE_HW_RENDER: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(256);
-}
-impl OH_NativeBuffer_Usage {
-    /// < For GPU write case */
-    pub const NATIVEBUFFER_USAGE_HW_TEXTURE: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(512);
-}
-impl OH_NativeBuffer_Usage {
-    /// < For GPU read case */
-    pub const NATIVEBUFFER_USAGE_CPU_READ_OFTEN: OH_NativeBuffer_Usage =
-        OH_NativeBuffer_Usage(65536);
-}
-impl OH_NativeBuffer_Usage {
-    /// < Often be mapped for direct CPU reads */
-    pub const NATIVEBUFFER_USAGE_ALIGNMENT_512: OH_NativeBuffer_Usage =
-        OH_NativeBuffer_Usage(262144);
-}
 impl ::core::ops::BitOr<OH_NativeBuffer_Usage> for OH_NativeBuffer_Usage {
     type Output = Self;
     #[inline]
@@ -237,6 +136,23 @@ impl ::core::ops::BitAndAssign for OH_NativeBuffer_Usage {
         self.0 &= rhs.0;
     }
 }
+impl OH_NativeBuffer_Usage {
+    pub const NATIVEBUFFER_USAGE_CPU_READ: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(1);
+    /// < CPU read buffer */
+    pub const NATIVEBUFFER_USAGE_CPU_WRITE: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(2);
+    /// < CPU write memory */
+    pub const NATIVEBUFFER_USAGE_MEM_DMA: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(8);
+    /// < Direct memory access (DMA) buffer */
+    pub const NATIVEBUFFER_USAGE_HW_RENDER: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(256);
+    /// < For GPU write case */
+    pub const NATIVEBUFFER_USAGE_HW_TEXTURE: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(512);
+    /// < For GPU read case */
+    pub const NATIVEBUFFER_USAGE_CPU_READ_OFTEN: OH_NativeBuffer_Usage =
+        OH_NativeBuffer_Usage(65536);
+    /// < Often be mapped for direct CPU reads */
+    pub const NATIVEBUFFER_USAGE_ALIGNMENT_512: OH_NativeBuffer_Usage =
+        OH_NativeBuffer_Usage(262144);
+}
 #[repr(transparent)]
 /// Indicates the usage of a native buffer.
 ///
@@ -255,100 +171,58 @@ impl OH_NativeBuffer_Format {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_CLUT8: OH_NativeBuffer_Format = OH_NativeBuffer_Format(0);
-}
-impl OH_NativeBuffer_Format {
     /// CLUT1 format
     ///
     /// Available since API-level: 12
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_CLUT1: OH_NativeBuffer_Format = OH_NativeBuffer_Format(1);
-}
-impl OH_NativeBuffer_Format {
     /// CLUT4 format
     ///
     /// Available since API-level: 12
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_CLUT4: OH_NativeBuffer_Format = OH_NativeBuffer_Format(2);
-}
-impl OH_NativeBuffer_Format {
     /// CLUT4 format
     ///
     /// Available since API-level: 12
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_RGB_565: OH_NativeBuffer_Format = OH_NativeBuffer_Format(3);
-}
-impl OH_NativeBuffer_Format {
     /// < RGB565 format */
     pub const NATIVEBUFFER_PIXEL_FMT_RGBA_5658: OH_NativeBuffer_Format = OH_NativeBuffer_Format(4);
-}
-impl OH_NativeBuffer_Format {
     /// < RGBA5658 format */
     pub const NATIVEBUFFER_PIXEL_FMT_RGBX_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(5);
-}
-impl OH_NativeBuffer_Format {
     /// < RGBX4444 format */
     pub const NATIVEBUFFER_PIXEL_FMT_RGBA_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(6);
-}
-impl OH_NativeBuffer_Format {
     /// < RGBA4444 format */
     pub const NATIVEBUFFER_PIXEL_FMT_RGB_444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(7);
-}
-impl OH_NativeBuffer_Format {
     /// < RGB444 format */
     pub const NATIVEBUFFER_PIXEL_FMT_RGBX_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(8);
-}
-impl OH_NativeBuffer_Format {
     /// < RGBX5551 format */
     pub const NATIVEBUFFER_PIXEL_FMT_RGBA_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(9);
-}
-impl OH_NativeBuffer_Format {
     /// < RGBA5551 format */
     pub const NATIVEBUFFER_PIXEL_FMT_RGB_555: OH_NativeBuffer_Format = OH_NativeBuffer_Format(10);
-}
-impl OH_NativeBuffer_Format {
     /// < RGB555 format */
     pub const NATIVEBUFFER_PIXEL_FMT_RGBX_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(11);
-}
-impl OH_NativeBuffer_Format {
     /// < RGBX8888 format */
     pub const NATIVEBUFFER_PIXEL_FMT_RGBA_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(12);
-}
-impl OH_NativeBuffer_Format {
     /// < RGBA8888 format */
     pub const NATIVEBUFFER_PIXEL_FMT_RGB_888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(13);
-}
-impl OH_NativeBuffer_Format {
     /// < RGB888 format */
     pub const NATIVEBUFFER_PIXEL_FMT_BGR_565: OH_NativeBuffer_Format = OH_NativeBuffer_Format(14);
-}
-impl OH_NativeBuffer_Format {
     /// < BGR565 format */
     pub const NATIVEBUFFER_PIXEL_FMT_BGRX_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(15);
-}
-impl OH_NativeBuffer_Format {
     /// < BGRX4444 format */
     pub const NATIVEBUFFER_PIXEL_FMT_BGRA_4444: OH_NativeBuffer_Format = OH_NativeBuffer_Format(16);
-}
-impl OH_NativeBuffer_Format {
     /// < BGRA4444 format */
     pub const NATIVEBUFFER_PIXEL_FMT_BGRX_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(17);
-}
-impl OH_NativeBuffer_Format {
     /// < BGRX5551 format */
     pub const NATIVEBUFFER_PIXEL_FMT_BGRA_5551: OH_NativeBuffer_Format = OH_NativeBuffer_Format(18);
-}
-impl OH_NativeBuffer_Format {
     /// < BGRA5551 format */
     pub const NATIVEBUFFER_PIXEL_FMT_BGRX_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(19);
-}
-impl OH_NativeBuffer_Format {
     /// < BGRX8888 format */
     pub const NATIVEBUFFER_PIXEL_FMT_BGRA_8888: OH_NativeBuffer_Format = OH_NativeBuffer_Format(20);
-}
-impl OH_NativeBuffer_Format {
     /// < BGRA8888 format */
     /// **
     /// * YUV422 interleaved format
@@ -357,8 +231,6 @@ impl OH_NativeBuffer_Format {
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YUV_422_I: OH_NativeBuffer_Format = OH_NativeBuffer_Format(21);
-}
-impl OH_NativeBuffer_Format {
     /// YCBCR422 semi-plannar format
     ///
     /// Available since API-level: 12
@@ -366,8 +238,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YCBCR_422_SP: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(22);
-}
-impl OH_NativeBuffer_Format {
     /// YCRCB422 semi-plannar format
     ///
     /// Available since API-level: 12
@@ -375,8 +245,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YCRCB_422_SP: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(23);
-}
-impl OH_NativeBuffer_Format {
     /// YCBCR420 semi-plannar format
     ///
     /// Available since API-level: 12
@@ -384,8 +252,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YCBCR_420_SP: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(24);
-}
-impl OH_NativeBuffer_Format {
     /// YCRCB420 semi-plannar format
     ///
     /// Available since API-level: 12
@@ -393,8 +259,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YCRCB_420_SP: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(25);
-}
-impl OH_NativeBuffer_Format {
     /// YCBCR422 plannar format
     ///
     /// Available since API-level: 12
@@ -402,8 +266,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YCBCR_422_P: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(26);
-}
-impl OH_NativeBuffer_Format {
     /// YCRCB422 plannar format
     ///
     /// Available since API-level: 12
@@ -411,8 +273,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YCRCB_422_P: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(27);
-}
-impl OH_NativeBuffer_Format {
     /// YCBCR420 plannar format
     ///
     /// Available since API-level: 12
@@ -420,8 +280,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YCBCR_420_P: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(28);
-}
-impl OH_NativeBuffer_Format {
     /// YCRCB420 plannar format
     ///
     /// Available since API-level: 12
@@ -429,8 +287,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YCRCB_420_P: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(29);
-}
-impl OH_NativeBuffer_Format {
     /// YUYV422 packed format
     ///
     /// Available since API-level: 12
@@ -438,8 +294,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YUYV_422_PKG: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(30);
-}
-impl OH_NativeBuffer_Format {
     /// UYVY422 packed format
     ///
     /// Available since API-level: 12
@@ -447,8 +301,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_UYVY_422_PKG: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(31);
-}
-impl OH_NativeBuffer_Format {
     /// YVYU422 packed format
     ///
     /// Available since API-level: 12
@@ -456,8 +308,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YVYU_422_PKG: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(32);
-}
-impl OH_NativeBuffer_Format {
     /// VYUY422 packed format
     ///
     /// Available since API-level: 12
@@ -465,8 +315,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_VYUY_422_PKG: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(33);
-}
-impl OH_NativeBuffer_Format {
     /// RGBA_1010102 packed format
     ///
     /// Available since API-level: 12
@@ -474,8 +322,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_RGBA_1010102: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(34);
-}
-impl OH_NativeBuffer_Format {
     /// YCBCR420 semi-planar 10bit packed format
     ///
     /// Available since API-level: 12
@@ -483,8 +329,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YCBCR_P010: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(35);
-}
-impl OH_NativeBuffer_Format {
     /// YCRCB420 semi-planar 10bit packed format
     ///
     /// Available since API-level: 12
@@ -492,16 +336,12 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_YCRCB_P010: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(36);
-}
-impl OH_NativeBuffer_Format {
     /// Raw 10bit packed format
     ///
     /// Available since API-level: 12
     #[cfg(feature = "api-12")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_RAW10: OH_NativeBuffer_Format = OH_NativeBuffer_Format(37);
-}
-impl OH_NativeBuffer_Format {
     /// vender mask format
     ///
     /// Available since API-level: 12
@@ -509,8 +349,6 @@ impl OH_NativeBuffer_Format {
     #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
     pub const NATIVEBUFFER_PIXEL_FMT_VENDER_MASK: OH_NativeBuffer_Format =
         OH_NativeBuffer_Format(2147418112);
-}
-impl OH_NativeBuffer_Format {
     /// vender mask format
     ///
     /// Available since API-level: 12
@@ -536,78 +374,34 @@ impl OH_NativeBuffer_TransformType {
     /// < No rotation
     pub const NATIVEBUFFER_ROTATE_NONE: OH_NativeBuffer_TransformType =
         OH_NativeBuffer_TransformType(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_TransformType {
     /// < Rotation by 90 degrees
     pub const NATIVEBUFFER_ROTATE_90: OH_NativeBuffer_TransformType =
         OH_NativeBuffer_TransformType(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_TransformType {
     /// < Rotation by 180 degrees
     pub const NATIVEBUFFER_ROTATE_180: OH_NativeBuffer_TransformType =
         OH_NativeBuffer_TransformType(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_TransformType {
     /// < Rotation by 270 degrees
     pub const NATIVEBUFFER_ROTATE_270: OH_NativeBuffer_TransformType =
         OH_NativeBuffer_TransformType(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_TransformType {
     /// < Flip horizontally
     pub const NATIVEBUFFER_FLIP_H: OH_NativeBuffer_TransformType = OH_NativeBuffer_TransformType(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_TransformType {
     /// < Flip vertically
     pub const NATIVEBUFFER_FLIP_V: OH_NativeBuffer_TransformType = OH_NativeBuffer_TransformType(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_TransformType {
     /// < Flip horizontally and rotate 90 degrees
     pub const NATIVEBUFFER_FLIP_H_ROT90: OH_NativeBuffer_TransformType =
         OH_NativeBuffer_TransformType(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_TransformType {
     /// < Flip vertically and rotate 90 degrees
     pub const NATIVEBUFFER_FLIP_V_ROT90: OH_NativeBuffer_TransformType =
         OH_NativeBuffer_TransformType(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_TransformType {
     /// < Flip horizontally and rotate 180 degrees
     pub const NATIVEBUFFER_FLIP_H_ROT180: OH_NativeBuffer_TransformType =
         OH_NativeBuffer_TransformType(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_TransformType {
     /// < Flip vertically and rotate 180 degrees
     pub const NATIVEBUFFER_FLIP_V_ROT180: OH_NativeBuffer_TransformType =
         OH_NativeBuffer_TransformType(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_TransformType {
     /// < Flip horizontally and rotate 270 degrees
     pub const NATIVEBUFFER_FLIP_H_ROT270: OH_NativeBuffer_TransformType =
         OH_NativeBuffer_TransformType(10);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_TransformType {
     /// < Flip vertically and rotate 270 degrees
     pub const NATIVEBUFFER_FLIP_V_ROT270: OH_NativeBuffer_TransformType =
         OH_NativeBuffer_TransformType(11);
@@ -631,73 +425,33 @@ impl OH_NativeBuffer_ColorGamut {
     /// < Native or default
     pub const NATIVEBUFFER_COLOR_GAMUT_NATIVE: OH_NativeBuffer_ColorGamut =
         OH_NativeBuffer_ColorGamut(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_ColorGamut {
     /// < Standard BT601
     pub const NATIVEBUFFER_COLOR_GAMUT_STANDARD_BT601: OH_NativeBuffer_ColorGamut =
         OH_NativeBuffer_ColorGamut(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_ColorGamut {
     /// < Standard BT709
     pub const NATIVEBUFFER_COLOR_GAMUT_STANDARD_BT709: OH_NativeBuffer_ColorGamut =
         OH_NativeBuffer_ColorGamut(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_ColorGamut {
     /// < DCI P3
     pub const NATIVEBUFFER_COLOR_GAMUT_DCI_P3: OH_NativeBuffer_ColorGamut =
         OH_NativeBuffer_ColorGamut(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_ColorGamut {
     /// < SRGB
     pub const NATIVEBUFFER_COLOR_GAMUT_SRGB: OH_NativeBuffer_ColorGamut =
         OH_NativeBuffer_ColorGamut(4);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_ColorGamut {
     /// < Adobe RGB
     pub const NATIVEBUFFER_COLOR_GAMUT_ADOBE_RGB: OH_NativeBuffer_ColorGamut =
         OH_NativeBuffer_ColorGamut(5);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_ColorGamut {
     /// < Display P3
     pub const NATIVEBUFFER_COLOR_GAMUT_DISPLAY_P3: OH_NativeBuffer_ColorGamut =
         OH_NativeBuffer_ColorGamut(6);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_ColorGamut {
     /// < BT2020
     pub const NATIVEBUFFER_COLOR_GAMUT_BT2020: OH_NativeBuffer_ColorGamut =
         OH_NativeBuffer_ColorGamut(7);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_ColorGamut {
     /// < BT2100 PQ
     pub const NATIVEBUFFER_COLOR_GAMUT_BT2100_PQ: OH_NativeBuffer_ColorGamut =
         OH_NativeBuffer_ColorGamut(8);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_ColorGamut {
     /// < BT2100 HLG
     pub const NATIVEBUFFER_COLOR_GAMUT_BT2100_HLG: OH_NativeBuffer_ColorGamut =
         OH_NativeBuffer_ColorGamut(9);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_ColorGamut {
     /// < Display BT2020
     pub const NATIVEBUFFER_COLOR_GAMUT_DISPLAY_BT2020: OH_NativeBuffer_ColorGamut =
         OH_NativeBuffer_ColorGamut(10);

--- a/src/native_window/native_window_ffi.rs
+++ b/src/native_window/native_window_ffi.rs
@@ -164,6 +164,7 @@ impl OH_NativeBuffer_ColorSpace {
 /// Available since API-level: 11
 ///
 /// Version: 1.0
+////
 ////**
 /// Indicates the color space of a native buffer.
 /// Move from native_buffer.h to native_common.h

--- a/src/native_window/native_window_ffi.rs
+++ b/src/native_window/native_window_ffi.rs
@@ -69,212 +69,88 @@ pub struct BufferHandle {
 impl OH_NativeBuffer_ColorSpace {
     /// None color space
     pub const OH_COLORSPACE_NONE: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(0);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT601_P | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_P << 16) | (RANGE_FULL << 21)
     pub const OH_COLORSPACE_BT601_EBU_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(1);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT601_N | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_N << 16) | (RANGE_FULL << 21)
     pub const OH_COLORSPACE_BT601_SMPTE_C_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(2);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT709 | (TRANSFUNC_BT709 << 8) | (MATRIX_BT709 << 16) | (RANGE_FULL << 21)
     pub const OH_COLORSPACE_BT709_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(3);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT2020 | (TRANSFUNC_HLG << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
     pub const OH_COLORSPACE_BT2020_HLG_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(4);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT2020 | (TRANSFUNC_PQ << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
     pub const OH_COLORSPACE_BT2020_PQ_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(5);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT601_P | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_P << 16) | (RANGE_LIMITED << 21)
     pub const OH_COLORSPACE_BT601_EBU_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(6);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT601_N | (TRANSFUNC_BT709 << 8) | (MATRIX_BT601_N << 16) | (RANGE_LIMITED << 21)
     pub const OH_COLORSPACE_BT601_SMPTE_C_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(7);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT709 | (TRANSFUNC_BT709 << 8) | (MATRIX_BT709 << 16) | (RANGE_LIMITED << 21)
     pub const OH_COLORSPACE_BT709_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(8);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT2020 | (TRANSFUNC_HLG << 8) | (MATRIX_BT2020 << 16) | (RANGE_LIMITED << 21)
     pub const OH_COLORSPACE_BT2020_HLG_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(9);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT2020 | (TRANSFUNC_PQ << 8) | (MATRIX_BT2020 << 16) | (RANGE_LIMITED << 21)
     pub const OH_COLORSPACE_BT2020_PQ_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(10);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_SRGB | (TRANSFUNC_SRGB << 8) | (MATRIX_BT601_N << 16) | (RANGE_FULL << 21)
     pub const OH_COLORSPACE_SRGB_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(11);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_SRGB << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
     pub const OH_COLORSPACE_P3_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(12);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_HLG << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
     pub const OH_COLORSPACE_P3_HLG_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(13);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_PQ << 8) | (MATRIX_P3 << 16) | (RANGE_FULL << 21)
     pub const OH_COLORSPACE_P3_PQ_FULL: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(14);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_ADOBERGB | (TRANSFUNC_ADOBERGB << 8) | (MATRIX_ADOBERGB << 16) | (RANGE_FULL << 21)
     pub const OH_COLORSPACE_ADOBERGB_FULL: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(15);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_SRGB | (TRANSFUNC_SRGB << 8) | (MATRIX_BT601_N << 16) | (RANGE_LIMITED << 21)
     pub const OH_COLORSPACE_SRGB_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(16);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_SRGB << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
     pub const OH_COLORSPACE_P3_LIMIT: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(17);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_HLG << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
     pub const OH_COLORSPACE_P3_HLG_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(18);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_PQ << 8) | (MATRIX_P3 << 16) | (RANGE_LIMITED << 21)
     pub const OH_COLORSPACE_P3_PQ_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(19);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_ADOBERGB | (TRANSFUNC_ADOBERGB << 8) | (MATRIX_ADOBERGB << 16) | (RANGE_LIMITED << 21)
     pub const OH_COLORSPACE_ADOBERGB_LIMIT: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(20);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_SRGB | (TRANSFUNC_LINEAR << 8)
     pub const OH_COLORSPACE_LINEAR_SRGB: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(21);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// equal to OH_COLORSPACE_LINEAR_SRGB
     pub const OH_COLORSPACE_LINEAR_BT709: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(22);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_P3_D65 | (TRANSFUNC_LINEAR << 8)
     pub const OH_COLORSPACE_LINEAR_P3: OH_NativeBuffer_ColorSpace = OH_NativeBuffer_ColorSpace(23);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT2020 | (TRANSFUNC_LINEAR << 8)
     pub const OH_COLORSPACE_LINEAR_BT2020: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(24);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// equal to OH_COLORSPACE_SRGB_FULL
     pub const OH_COLORSPACE_DISPLAY_SRGB: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(25);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// equal to OH_COLORSPACE_P3_FULL
     pub const OH_COLORSPACE_DISPLAY_P3_SRGB: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(26);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// equal to OH_COLORSPACE_P3_HLG_FULL
     pub const OH_COLORSPACE_DISPLAY_P3_HLG: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(27);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// equal to OH_COLORSPACE_P3_PQ_FULL
     pub const OH_COLORSPACE_DISPLAY_P3_PQ: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(28);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// COLORPRIMARIES_BT2020 | (TRANSFUNC_SRGB << 8) | (MATRIX_BT2020 << 16) | (RANGE_FULL << 21)
     pub const OH_COLORSPACE_DISPLAY_BT2020_SRGB: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(29);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// equal to OH_COLORSPACE_BT2020_HLG_FULL
     pub const OH_COLORSPACE_DISPLAY_BT2020_HLG: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(30);
-}
-#[cfg(feature = "api-11")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
-impl OH_NativeBuffer_ColorSpace {
     /// equal to OH_COLORSPACE_BT2020_PQ_FULL
     pub const OH_COLORSPACE_DISPLAY_BT2020_PQ: OH_NativeBuffer_ColorSpace =
         OH_NativeBuffer_ColorSpace(31);
@@ -307,16 +183,8 @@ pub struct OH_NativeBuffer_ColorSpace(pub ::core::ffi::c_uint);
 impl OH_NativeBuffer_MetadataKey {
     /// value: OH_NativeBuffer_MetadataType
     pub const OH_HDR_METADATA_TYPE: OH_NativeBuffer_MetadataKey = OH_NativeBuffer_MetadataKey(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_MetadataKey {
     /// value: OH_NativeBuffer_StaticMetadata
     pub const OH_HDR_STATIC_METADATA: OH_NativeBuffer_MetadataKey = OH_NativeBuffer_MetadataKey(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OH_NativeBuffer_MetadataKey {
     /// byte stream of SEI in video stream
     pub const OH_HDR_DYNAMIC_METADATA: OH_NativeBuffer_MetadataKey = OH_NativeBuffer_MetadataKey(2);
 }
@@ -514,17 +382,11 @@ impl OHScalingMode {
     /// the window content is not updated until a buffer of
     /// the window size is received
     pub const OH_SCALING_MODE_FREEZE: OHScalingMode = OHScalingMode(0);
-}
-impl OHScalingMode {
     /// the buffer is scaled in two dimensions to match the window size
     pub const OH_SCALING_MODE_SCALE_TO_WINDOW: OHScalingMode = OHScalingMode(1);
-}
-impl OHScalingMode {
     /// the buffer is uniformly scaled so that the smaller size of
     /// the buffer matches the window size
     pub const OH_SCALING_MODE_SCALE_CROP: OHScalingMode = OHScalingMode(2);
-}
-impl OHScalingMode {
     /// the window is clipped to the size of the buffer's clipping rectangle
     /// pixels outside the clipping rectangle are considered fully transparent.
     pub const OH_SCALING_MODE_NO_SCALE_CROP: OHScalingMode = OHScalingMode(3);
@@ -542,30 +404,14 @@ impl OHScalingModeV2 {
     /// the window content is not updated until a buffer of
     /// the window size is received
     pub const OH_SCALING_MODE_FREEZE_V2: OHScalingModeV2 = OHScalingModeV2(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OHScalingModeV2 {
     /// the buffer is scaled in two dimensions to match the window size
     pub const OH_SCALING_MODE_SCALE_TO_WINDOW_V2: OHScalingModeV2 = OHScalingModeV2(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OHScalingModeV2 {
     /// the buffer is uniformly scaled so that the smaller size of
     /// the buffer matches the window size
     pub const OH_SCALING_MODE_SCALE_CROP_V2: OHScalingModeV2 = OHScalingModeV2(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OHScalingModeV2 {
     /// the window is clipped to the size of the buffer's clipping rectangle
     /// pixels outside the clipping rectangle are considered fully transparent.
     pub const OH_SCALING_MODE_NO_SCALE_CROP_V2: OHScalingModeV2 = OHScalingModeV2(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OHScalingModeV2 {
     /// Adapt to the buffer and scale proportionally to the buffer size. Prioritize displaying all buffer content.
     /// If the size is not the same as the window size, fill the unfilled area of the window with a background color.
     pub const OH_SCALING_MODE_SCALE_FIT_V2: OHScalingModeV2 = OHScalingModeV2(4);
@@ -580,44 +426,18 @@ impl OHScalingModeV2 {
 pub struct OHScalingModeV2(pub ::core::ffi::c_uint);
 impl OHHDRMetadataKey {
     pub const OH_METAKEY_RED_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(0);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_RED_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(1);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_GREEN_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(2);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_GREEN_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(3);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_BLUE_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(4);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_BLUE_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(5);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_WHITE_PRIMARY_X: OHHDRMetadataKey = OHHDRMetadataKey(6);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_WHITE_PRIMARY_Y: OHHDRMetadataKey = OHHDRMetadataKey(7);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_MAX_LUMINANCE: OHHDRMetadataKey = OHHDRMetadataKey(8);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_MIN_LUMINANCE: OHHDRMetadataKey = OHHDRMetadataKey(9);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_MAX_CONTENT_LIGHT_LEVEL: OHHDRMetadataKey = OHHDRMetadataKey(10);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_MAX_FRAME_AVERAGE_LIGHT_LEVEL: OHHDRMetadataKey = OHHDRMetadataKey(11);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_HDR10_PLUS: OHHDRMetadataKey = OHHDRMetadataKey(12);
-}
-impl OHHDRMetadataKey {
     pub const OH_METAKEY_HDR_VIVID: OHHDRMetadataKey = OHHDRMetadataKey(13);
 }
 #[repr(transparent)]
@@ -652,25 +472,9 @@ pub struct OHExtDataHandle {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 impl OHSurfaceSource {
     pub const OH_SURFACE_SOURCE_DEFAULT: OHSurfaceSource = OHSurfaceSource(0);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OHSurfaceSource {
     pub const OH_SURFACE_SOURCE_UI: OHSurfaceSource = OHSurfaceSource(1);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OHSurfaceSource {
     pub const OH_SURFACE_SOURCE_GAME: OHSurfaceSource = OHSurfaceSource(2);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OHSurfaceSource {
     pub const OH_SURFACE_SOURCE_CAMERA: OHSurfaceSource = OHSurfaceSource(3);
-}
-#[cfg(feature = "api-12")]
-#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
-impl OHSurfaceSource {
     pub const OH_SURFACE_SOURCE_VIDEO: OHSurfaceSource = OHSurfaceSource(4);
 }
 #[repr(transparent)]


### PR DESCRIPTION
Use patched bindgen to merge all the duplicate impl blocks for newtype enums.