### PR TITLE
Fix missing documentation for overlapping typedefs

### DIFF
--- a/components/arkui/src/drag_and_drop/drag_and_drop_ffi.rs
+++ b/components/arkui/src/drag_and_drop/drag_and_drop_ffi.rs
@@ -117,22 +117,52 @@ impl ArkUI_DragStatus {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ArkUI_DragStatus(pub ::core::ffi::c_int);
+/// Defines a struct for a component event.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_NodeEvent {
     _unused: [u8; 0],
 }
+/// Defines a struct for a drag event.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_DragEvent {
     _unused: [u8; 0],
 }
+/// Defines a struct for custom drag preview options.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_DragPreviewOption {
     _unused: [u8; 0],
 }
+/// Defines a struct for a drag action.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_DragAction {
     _unused: [u8; 0],
 }
+/// Defines a struct for drag and drop information returned through a drag status listener.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_DragAndDropInfo {
     _unused: [u8; 0],

--- a/components/arkui/src/drawable_descriptor/drawable_descriptor_ffi.rs
+++ b/components/arkui/src/drawable_descriptor/drawable_descriptor_ffi.rs
@@ -6,6 +6,12 @@
 use crate::native_type::*;
 pub use ohos_sys_opaque_types::OH_PixelmapNative;
 
+/// Defines the drawable descriptor.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_DrawableDescriptor {
     _unused: [u8; 0],

--- a/components/arkui/src/native_animate/native_animate_ffi.rs
+++ b/components/arkui/src/native_animate/native_animate_ffi.rs
@@ -36,10 +36,22 @@ pub struct ArkUI_AnimateCompleteCallback {
     /// Custom type.
     pub userData: *mut ::core::ffi::c_void,
 }
+/// Defines the animation configuration.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_AnimateOption {
     _unused: [u8; 0],
 }
+/// Defines an interpolation curve.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_Curve {
     _unused: [u8; 0],
@@ -51,10 +63,22 @@ pub struct ArkUI_Curve {
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 pub type ArkUI_CurveHandle = *mut ArkUI_Curve;
+/// Defines the keyframe animation parameter object.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_KeyframeAnimateOption {
     _unused: [u8; 0],
 }
+/// Defines the animator parameter object.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_AnimatorOption {
     _unused: [u8; 0],
@@ -70,14 +94,32 @@ pub struct ArkUI_Animator {
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 pub type ArkUI_AnimatorHandle = *mut ArkUI_Animator;
+/// Defines the animator callback event object.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_AnimatorEvent {
     _unused: [u8; 0],
 }
+/// Defines the callback object when the animator receives a frame.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_AnimatorOnFrameEvent {
     _unused: [u8; 0],
 }
+/// Defines the transition effect.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_TransitionEffect {
     _unused: [u8; 0],

--- a/components/arkui/src/native_dialog/native_dialog_ffi.rs
+++ b/components/arkui/src/native_dialog/native_dialog_ffi.rs
@@ -34,6 +34,12 @@ pub struct ArkUI_DismissReason(pub ::core::ffi::c_uint);
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 pub type ArkUI_OnWillDismissEvent =
     ::core::option::Option<unsafe extern "C" fn(reason: i32) -> bool>;
+/// Defines a struct for a dialog box dismiss event.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_DialogDismissEvent {
     _unused: [u8; 0],

--- a/components/arkui/src/native_gesture/native_gesture_ffi.rs
+++ b/components/arkui/src/native_gesture/native_gesture_ffi.rs
@@ -6,14 +6,32 @@
 use crate::native_type::*;
 use crate::ui_input_event::ArkUI_UIInputEvent;
 
+/// Defines a gesture recognizer.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_GestureRecognizer {
     _unused: [u8; 0],
 }
+/// Defines the gesture interruption information.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_GestureInterruptInfo {
     _unused: [u8; 0],
 }
+/// Defines the gesture event.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_GestureEvent {
     _unused: [u8; 0],
@@ -239,10 +257,22 @@ pub type ArkUI_GestureRecognizerHandle = *mut ArkUI_GestureRecognizer;
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 pub type ArkUI_GestureRecognizerHandleArray = *mut ArkUI_GestureRecognizerHandle;
+/// Defines a <b>GestureEventTargetInfo</b> object that provides information about a gesture event target.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_GestureEventTargetInfo {
     _unused: [u8; 0],
 }
+/// Defines a parallel internal gesture event.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_ParallelInnerGestureEvent {
     _unused: [u8; 0],

--- a/components/arkui/src/native_interface_accessibility/native_interface_accessibility_ffi.rs
+++ b/components/arkui/src/native_interface_accessibility/native_interface_accessibility_ffi.rs
@@ -6,14 +6,32 @@
 use crate::native_type::*;
 use ohos_sys_opaque_types::ArkUI_AccessibilityProvider;
 
+/// Defines a struct for accessibility element information.
+///
+///
+/// Available since API-level: 13
+#[cfg(feature = "api-13")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
 #[repr(C)]
 pub struct ArkUI_AccessibilityElementInfo {
     _unused: [u8; 0],
 }
+/// Defines a struct for accessibility event information.
+///
+///
+/// Available since API-level: 13
+#[cfg(feature = "api-13")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
 #[repr(C)]
 pub struct ArkUI_AccessibilityEventInfo {
     _unused: [u8; 0],
 }
+/// Defines a struct for accessibility action arguments.
+///
+///
+/// Available since API-level: 13
+#[cfg(feature = "api-13")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
 #[repr(C)]
 pub struct ArkUI_AccessibilityActionArguments {
     _unused: [u8; 0],
@@ -324,6 +342,12 @@ impl ArkUI_AccessibilityFocusMoveDirection {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ArkUI_AccessibilityFocusMoveDirection(pub ::core::ffi::c_uint);
+/// Defines a struct for the accessibility element information list.
+///
+///
+/// Available since API-level: 13
+#[cfg(feature = "api-13")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
 #[repr(C)]
 pub struct ArkUI_AccessibilityElementInfoList {
     _unused: [u8; 0],

--- a/components/arkui/src/native_node/native_node_ffi.rs
+++ b/components/arkui/src/native_node/native_node_ffi.rs
@@ -7809,6 +7809,12 @@ impl ArkUI_NodeEventType {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ArkUI_NodeEventType(pub ::core::ffi::c_uint);
+/// Defines the common structure type of a component event.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_NodeEvent {
     _unused: [u8; 0],
@@ -7862,6 +7868,12 @@ impl ArkUI_NodeCustomEventType {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ArkUI_NodeCustomEventType(pub ::core::ffi::c_uint);
+/// Defines the general structure of a custom component event.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_NodeCustomEvent {
     _unused: [u8; 0],
@@ -7877,6 +7889,12 @@ pub struct ArkUI_NodeAdapter {
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 pub type ArkUI_NodeAdapterHandle = *mut ArkUI_NodeAdapter;
+/// Defines the component adapter event.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_NodeAdapterEvent {
     _unused: [u8; 0],
@@ -8628,6 +8646,11 @@ impl ArkUI_NodeContentEventType {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ArkUI_NodeContentEventType(pub ::core::ffi::c_uint);
+/// Defines the general structure of a node content event.
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_NodeContentEvent {
     _unused: [u8; 0],

--- a/components/arkui/src/native_type/native_type_ffi.rs
+++ b/components/arkui/src/native_type/native_type_ffi.rs
@@ -36,10 +36,22 @@ pub type ArkUI_NodeContentHandle = *mut ArkUI_NodeContent;
 pub struct ArkUI_NativeDialog {
     _unused: [u8; 0],
 }
+/// Sets the size constraints of a component during component layout.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_LayoutConstraint {
     _unused: [u8; 0],
 }
+/// Defines the structure of the component drawing context.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_DrawContext {
     _unused: [u8; 0],
@@ -58,14 +70,32 @@ pub type ArkUI_NodeHandle = *mut ArkUI_Node;
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 pub type ArkUI_NativeDialogHandle = *mut ArkUI_NativeDialog;
+/// Defines the water flow section configuration.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_WaterFlowSectionOption {
     _unused: [u8; 0],
 }
+/// Define the configuration information of the Item within the ListitemSwipeActionOption method.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_ListItemSwipeActionItem {
     _unused: [u8; 0],
 }
+/// Define the configuration information for the ListitemSwipeActionOption method.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_ListItemSwipeActionOption {
     _unused: [u8; 0],
@@ -87,46 +117,113 @@ pub struct ArkUI_Context {
 #[cfg(feature = "api-12")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 pub type ArkUI_ContextHandle = *mut ArkUI_Context;
+/// Defines the navigation indicator style for the swiper.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_SwiperIndicator {
     _unused: [u8; 0],
 }
+/// Define the data objects of styled string supported by text components.
+///
+///
+/// Available since API-level: 14
+#[cfg(feature = "api-14")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
 #[repr(C)]
 pub struct ArkUI_StyledString_Descriptor {
     _unused: [u8; 0],
 }
+/// specifies the alignment rules for subcomponents set in relative containers.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_AlignmentRuleOption {
     _unused: [u8; 0],
 }
+/// guideLine parameters, used to define the id, direction and position of the guideline.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_GuidelineOption {
     _unused: [u8; 0],
 }
+/// barrier parameter, used to define the id,
+/// direction and components of the barrier that it depends on when generating it.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_BarrierOption {
     _unused: [u8; 0],
 }
+/// Define the ChildrenMainSize class information for a List.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_ListChildrenMainSize {
     _unused: [u8; 0],
 }
+/// Defines the image frame.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_ImageAnimatorFrameInfo {
     _unused: [u8; 0],
 }
+/// Defines the accessibility state for the component.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_AccessibilityState {
     _unused: [u8; 0],
 }
+/// Defines the accessibility value for the component.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_AccessibilityValue {
     _unused: [u8; 0],
 }
+/// Define the information of the Custom Property class for custom properties.
+///
+///
+/// Available since API-level: 14
+#[cfg(feature = "api-14")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
 #[repr(C)]
 pub struct ArkUI_CustomProperty {
     _unused: [u8; 0],
 }
+/// Define ActiveChildenInfo class information.
+///
+///
+/// Available since API-level: 14
+#[cfg(feature = "api-14")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
 #[repr(C)]
 pub struct ArkUI_ActiveChildrenInfo {
     _unused: [u8; 0],
@@ -2620,14 +2717,32 @@ pub struct ArkUI_RotationOptions {
     /// Distance from the user to the z=0 plane.
     pub perspective: f32,
 }
+/// Defines a struct for the measurement information of a custom span.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_CustomSpanMeasureInfo {
     _unused: [u8; 0],
 }
+/// Defines a struct for the measurement metrics of a custom span.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_CustomSpanMetrics {
     _unused: [u8; 0],
 }
+/// Defines a struct for the drawing information of a custom span.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_CustomSpanDrawInfo {
     _unused: [u8; 0],
@@ -2738,6 +2853,12 @@ impl ArkUI_SafeAreaEdge {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ArkUI_SafeAreaEdge(pub ::core::ffi::c_uint);
+/// Defines parameter used by the system font style callback event.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_SystemFontStyleEvent {
     _unused: [u8; 0],

--- a/components/arkui/src/styled_string/styled_string_ffi.rs
+++ b/components/arkui/src/styled_string/styled_string_ffi.rs
@@ -5,6 +5,12 @@
 #![allow(non_snake_case)]
 use crate::native_type::*;
 
+/// Defines formatted string data objects supported by the text component.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_StyledString {
     _unused: [u8; 0],

--- a/components/arkui/src/ui_input_event/ui_input_event_ffi.rs
+++ b/components/arkui/src/ui_input_event/ui_input_event_ffi.rs
@@ -5,6 +5,12 @@
 #![allow(non_snake_case)]
 use crate::native_type::*;
 
+/// Defines the UI input event.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct ArkUI_UIInputEvent {
     _unused: [u8; 0],

--- a/components/drawing/src/text_declaration/text_declaration_ffi.rs
+++ b/components/drawing/src/text_declaration/text_declaration_ffi.rs
@@ -5,42 +5,113 @@
 #![allow(non_snake_case)]
 use crate::types::*;
 
+/// Defines an <b>OH_Drawing_FontCollection</b>, which is used to load fonts.
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_Drawing_FontCollection {
     _unused: [u8; 0],
 }
+/// Defines an <b>OH_Drawing_Typography</b>, which is used to manage the typography layout and display.
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_Drawing_Typography {
     _unused: [u8; 0],
 }
+/// Defines an <b>OH_Drawing_TextStyle</b>, which is used to manage text colors and decorations.
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_Drawing_TextStyle {
     _unused: [u8; 0],
 }
+/// Defines an <b>OH_Drawing_TypographyStyle</b>, which is used to manage the typography style,
+/// such as the text direction.
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_Drawing_TypographyStyle {
     _unused: [u8; 0],
 }
+/// Defines an <b>OH_Drawing_TypographyCreate</b>, which is used to create an <b>OH_Drawing_Typography</b> object.
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_Drawing_TypographyCreate {
     _unused: [u8; 0],
 }
+/// Defines an <b>OH_Drawing_TextBox</b>, which is used to create an <b>OH_Drawing_TextBox</b> object.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_TextBox {
     _unused: [u8; 0],
 }
+/// Defines an <b>OH_Drawing_PositionAndAffinity</b>,
+/// which is used to create an <b>OH_Drawing_PositionAndAffinity</b> object.
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_PositionAndAffinity {
     _unused: [u8; 0],
 }
+/// Defines an <b>OH_Drawing_Range</b>, which is used to create an <b>OH_Drawing_Range</b> object.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_Range {
     _unused: [u8; 0],
 }
+/// Defines an <b>OH_Drawing_FontParser</b>, which is used to parse system font files.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_FontParser {
     _unused: [u8; 0],
 }
+/// Defines an <b>OH_Drawing_TextShadow</b>, which is used to manage text shadow.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_TextShadow {
     _unused: [u8; 0],

--- a/components/drawing/src/types/types_ffi.rs
+++ b/components/drawing/src/types/types_ffi.rs
@@ -4,38 +4,101 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+/// Defines a rectangular canvas on which various shapes, images,
+/// and texts can be drawn by using the brush and pen.
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_Drawing_Canvas {
     _unused: [u8; 0],
 }
+/// Defines a pen, which is used to describe the style and color to outline a shape.
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_Drawing_Pen {
     _unused: [u8; 0],
 }
+/// Defines a region, which is used to represent an enclosed area on the canvas layer.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_Region {
     _unused: [u8; 0],
 }
+/// Defines as a brush, which is used to describe the style and color to fill in a shape.
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_Drawing_Brush {
     _unused: [u8; 0],
 }
+/// Defines a path, which is used to customize various shapes.
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_Drawing_Path {
     _unused: [u8; 0],
 }
+/// Defines a bitmap, which is a memory that contains the pixel data of a shape.
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_Drawing_Bitmap {
     _unused: [u8; 0],
 }
+/// Defines a point, which is used to describe the coordinate point.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_Point {
     _unused: [u8; 0],
 }
+/// Defines a pixelmap, which is used to wrap real pixelmap supported by image framework.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_PixelMap {
     _unused: [u8; 0],
 }
+/// Define color space to determine color information.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_ColorSpace {
     _unused: [u8; 0],
@@ -78,82 +141,243 @@ pub struct OH_Drawing_Point3D {
     pub y: f32,
     pub z: f32,
 }
+/// Defines a pathEffect, which is used to affects stroked paths.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_PathEffect {
     _unused: [u8; 0],
 }
+/// Defines a rect, which is used to describe the rectangle.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_Rect {
     _unused: [u8; 0],
 }
+/// Defines a roundRect, which is used to describe the round rectangle.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_RoundRect {
     _unused: [u8; 0],
 }
+/// Defines a matrix, which is used to describe the transforming coordinates.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_Matrix {
     _unused: [u8; 0],
 }
+/// Defines a shaderEffect, which is used to describe the source color(s) for what is being drawn.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_ShaderEffect {
     _unused: [u8; 0],
 }
+/// Defines a shadowLayer, which is used to draw shaded parts.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_ShadowLayer {
     _unused: [u8; 0],
 }
+/// Defines a filter, which is used to store maskFilter, colorFilter and imageFilter.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_Filter {
     _unused: [u8; 0],
 }
+/// Defines a maskFilter, which is used to perform transformations on the mask before drawing it.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_MaskFilter {
     _unused: [u8; 0],
 }
+/// Defines a colorFilter, which is called a color and returns a new color.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_ColorFilter {
     _unused: [u8; 0],
 }
+/// Defines a font, which is used to describe the font.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_Font {
     _unused: [u8; 0],
 }
+/// Defines a memoryStream, which is used to describe the memory stream.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_MemoryStream {
     _unused: [u8; 0],
 }
+/// Defines fontArguments, which is used to describe the arguments for a font.
+///
+///
+/// Available since API-level: 13
+///
+/// Version: 1.0
+#[cfg(feature = "api-13")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
 #[repr(C)]
 pub struct OH_Drawing_FontArguments {
     _unused: [u8; 0],
 }
+/// Defines a typeface, which is used to describe the typeface.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_Typeface {
     _unused: [u8; 0],
 }
+/// Defines a textBlob, which combines multiple text runs into an immutable container.
+/// Each text run consists of glyphs and positions.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_TextBlob {
     _unused: [u8; 0],
 }
+/// Defines a image, which is used to describe a two dimensional array of pixels to draw.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_Image {
     _unused: [u8; 0],
 }
+/// Defines a image filter, which is used to operate on all the color bits of pixels that make up an image.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_ImageFilter {
     _unused: [u8; 0],
 }
+/// Defines a sampling options, which is used to describe the sampling mode.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_SamplingOptions {
     _unused: [u8; 0],
 }
+/// Defines a textBlobBuilder, which is used to build the textBlob.
+///
+///
+/// Available since API-level: 11
+///
+/// Version: 1.0
+#[cfg(feature = "api-11")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
 #[repr(C)]
 pub struct OH_Drawing_TextBlobBuilder {
     _unused: [u8; 0],
 }
+/// Defines a GPU context, which is used to describe the GPU backend context.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_GpuContext {
     _unused: [u8; 0],
 }
+/// Defines a surface, which is used to manage the pixels that a canvas draws into.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_Surface {
     _unused: [u8; 0],
@@ -370,22 +594,62 @@ impl OH_Drawing_TextEncoding {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct OH_Drawing_TextEncoding(pub ::core::ffi::c_uint);
+/// Defines a OH_Drawing_FontMgr, which is used to manage font family.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_FontMgr {
     _unused: [u8; 0],
 }
+/// Defines a OH_Drawing_FontStyleSet, which is used to manage font style.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OH_Drawing_FontStyleSet {
     _unused: [u8; 0],
 }
+/// Define OH_Drawing_RecordCmdUtils, which is used to generate drawing commands tool.
+///
+///
+/// Available since API-level: 13
+///
+/// Version: 1.0
+#[cfg(feature = "api-13")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
 #[repr(C)]
 pub struct OH_Drawing_RecordCmdUtils {
     _unused: [u8; 0],
 }
+/// Define OH_Drawing_RecordCmd, which is used to replay drawing commands.
+///
+///
+/// Available since API-level: 13
+///
+/// Version: 1.0
+#[cfg(feature = "api-13")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
 #[repr(C)]
 pub struct OH_Drawing_RecordCmd {
     _unused: [u8; 0],
 }
+/// Defines an array object, which is used to store multiple NDK object.
+///
+///
+/// Available since API-level: 14
+///
+/// Version: 1.0
+#[cfg(feature = "api-14")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
 #[repr(C)]
 pub struct OH_Drawing_Array {
     _unused: [u8; 0],

--- a/components/inputmethod/src/attach_options/attach_options_ffi.rs
+++ b/components/inputmethod/src/attach_options/attach_options_ffi.rs
@@ -5,6 +5,14 @@
 #![allow(non_snake_case)]
 use crate::types::*;
 
+/// Define the InputMethod_AttachOptions structure type.
+///
+/// The options when attaching input method.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct InputMethod_AttachOptions {
     _unused: [u8; 0],

--- a/components/inputmethod/src/cursor_info/cursor_info_ffi.rs
+++ b/components/inputmethod/src/cursor_info/cursor_info_ffi.rs
@@ -5,6 +5,14 @@
 #![allow(non_snake_case)]
 use crate::types::*;
 
+/// Define the InputMethod_CursorInfo structure type.
+///
+/// The coordinates and width and height information of the cursor.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct InputMethod_CursorInfo {
     _unused: [u8; 0],

--- a/components/inputmethod/src/inputmethod_proxy/inputmethod_proxy_ffi.rs
+++ b/components/inputmethod/src/inputmethod_proxy/inputmethod_proxy_ffi.rs
@@ -7,6 +7,14 @@ use crate::cursor_info::InputMethod_CursorInfo;
 use crate::private_command::InputMethod_PrivateCommand;
 use crate::types::*;
 
+/// Define the InputMethod_InputMethodProxy structure type.
+///
+/// Provides methods for controlling input method.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct InputMethod_InputMethodProxy {
     _unused: [u8; 0],

--- a/components/inputmethod/src/private_command/private_command_ffi.rs
+++ b/components/inputmethod/src/private_command/private_command_ffi.rs
@@ -5,6 +5,14 @@
 #![allow(non_snake_case)]
 use crate::types::*;
 
+/// Define the InputMethod_PrivateCommand structure type.
+///
+/// The private command between text editor and input method.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct InputMethod_PrivateCommand {
     _unused: [u8; 0],

--- a/components/inputmethod/src/text_avoid_info/text_avoid_info_ffi.rs
+++ b/components/inputmethod/src/text_avoid_info/text_avoid_info_ffi.rs
@@ -5,6 +5,14 @@
 #![allow(non_snake_case)]
 use crate::types::*;
 
+/// Define the InputMethod_TextAvoidInfo structure type.
+///
+/// Information for text editor to avoid the keyboard.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct InputMethod_TextAvoidInfo {
     _unused: [u8; 0],

--- a/components/inputmethod/src/text_config/text_config_ffi.rs
+++ b/components/inputmethod/src/text_config/text_config_ffi.rs
@@ -7,6 +7,14 @@ use crate::cursor_info::InputMethod_CursorInfo;
 use crate::text_avoid_info::InputMethod_TextAvoidInfo;
 use crate::types::*;
 
+/// Define the InputMethod_TextConfig structure type.
+///
+/// The configuration of the text editor.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct InputMethod_TextConfig {
     _unused: [u8; 0],

--- a/components/inputmethod/src/text_editor_proxy/text_editor_proxy_ffi.rs
+++ b/components/inputmethod/src/text_editor_proxy/text_editor_proxy_ffi.rs
@@ -7,6 +7,17 @@ use crate::private_command::InputMethod_PrivateCommand;
 use crate::text_config::InputMethod_TextConfig;
 use crate::types::*;
 
+/// Define the InputMethod_TextEditorProxy structure type.
+///
+/// Provides methods for getting requests and notifications from input method.
+///
+/// When input method sends request or notification to editor, the methods will be called.
+///
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct InputMethod_TextEditorProxy {
     _unused: [u8; 0],

--- a/components/multimodal-input/src/input_manager/input_manager_ffi.rs
+++ b/components/multimodal-input/src/input_manager/input_manager_ffi.rs
@@ -197,26 +197,62 @@ impl InputEvent_SourceType {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct InputEvent_SourceType(pub ::core::ffi::c_uint);
+/// Defines key information, which identifies a key pressing behavior. For example, the Ctrl key information contains the key value and key type.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct Input_KeyState {
     _unused: [u8; 0],
 }
+/// The key event to be injected.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct Input_KeyEvent {
     _unused: [u8; 0],
 }
+/// The mouse event to be injected.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct Input_MouseEvent {
     _unused: [u8; 0],
 }
+/// The touch event to be injected.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct Input_TouchEvent {
     _unused: [u8; 0],
 }
+/// Enumerates axis events.
+///
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct Input_AxisEvent {
     _unused: [u8; 0],
 }
+/// Defines the hot key structure.
+///
+///
+/// Available since API-level: 14
+#[cfg(feature = "api-14")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
 #[repr(C)]
 pub struct Input_Hotkey {
     _unused: [u8; 0],
@@ -274,6 +310,12 @@ pub struct InputErrorCode(pub core::num::NonZero<::core::ffi::c_uint>);
 #[cfg_attr(docsrs, doc(cfg(feature = "api-14")))]
 pub type Input_HotkeyCallback =
     ::core::option::Option<unsafe extern "C" fn(hotkey: *mut Input_Hotkey)>;
+/// Represents information about the input device.
+///
+///
+/// Available since API-level: 13
+#[cfg(feature = "api-13")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-13")))]
 #[repr(C)]
 pub struct Input_DeviceInfo {
     _unused: [u8; 0],
@@ -369,6 +411,11 @@ pub struct Input_DeviceListener {
     /// Callback for device removal events
     pub deviceRemovedCallback: Input_DeviceRemovedCallback,
 }
+/// Defines event interceptor options.
+///
+/// Available since API-level: 12
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct Input_InterceptorOptions {
     _unused: [u8; 0],

--- a/components/opaque-types/wrapper.h
+++ b/components/opaque-types/wrapper.h
@@ -4,6 +4,9 @@
 #include "multimedia/image_framework/image_pixel_map_mdk.h"
 #include "native_window/external_window.h"
 #include "multimedia/image_framework/image/image_source_native.h"
+#include "database/udmf/udmf.h"
+#include "database/udmf/uds.h"
+#include "database/udmf/utd.h"
 #if BINDGEN_OHOS_API_LEVEL >= 13
 #include "arkui/native_interface_accessibility.h"
 #include "native_color_space_manager/native_color_space_manager.h"

--- a/components/rawfile/src/raw_dir/raw_dir_ffi.rs
+++ b/components/rawfile/src/raw_dir/raw_dir_ffi.rs
@@ -6,6 +6,14 @@
 #[cfg(doc)]
 use crate::raw_file_manager::{OH_ResourceManager_OpenRawDir, OH_ResourceManager_OpenRawFile};
 
+/// Provides access to a raw file directory.
+///
+///
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct RawDir {
     _unused: [u8; 0],

--- a/components/rawfile/src/raw_file_manager/raw_file_manager_ffi.rs
+++ b/components/rawfile/src/raw_file_manager/raw_file_manager_ffi.rs
@@ -13,6 +13,15 @@ use crate::RawFile;
 use crate::RawFile64;
 use ohos_sys_opaque_types::{napi_env, napi_value};
 
+/// Presents the resource manager.
+///
+/// This class encapsulates the native implementation of the JavaScript resource manager. The pointer to a
+/// <b>ResourceManager</b> object can be obtained by calling [`OH_ResourceManager_InitNativeResourceManager`].
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct NativeResourceManager {
     _unused: [u8; 0],

--- a/components/rawfile/src/raw_file_types_ffi.rs
+++ b/components/rawfile/src/raw_file_types_ffi.rs
@@ -11,6 +11,14 @@ use crate::{
     raw_file_manager::OH_ResourceManager_OpenRawFile,
 };
 
+/// Provides access to a raw file.
+///
+///
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct RawFile {
     _unused: [u8; 0],

--- a/components/xcomponent/src/xcomponent_ffi.rs
+++ b/components/xcomponent/src/xcomponent_ffi.rs
@@ -649,6 +649,12 @@ pub struct OH_NativeXComponent_MouseEvent {
     /// Mouse event button.
     pub button: OH_NativeXComponent_MouseEventButton,
 }
+/// Provides an encapsulated <b>OH_NativeXComponent</b> instance.
+///
+///
+/// Available since API-level: 8
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_NativeXComponent {
     _unused: [u8; 0],
@@ -697,6 +703,12 @@ pub struct OH_NativeXComponent_MouseEvent_Callback {
         unsafe extern "C" fn(component: *mut OH_NativeXComponent, isHover: bool),
     >,
 }
+/// Provides an encapsulated <b>OH_NativeXComponent_KeyEvent</b> instance.
+///
+///
+/// Available since API-level: 10
+///
+/// Version: 1.0
 #[repr(C)]
 pub struct OH_NativeXComponent_KeyEvent {
     _unused: [u8; 0],

--- a/src/native_window/native_window_ffi.rs
+++ b/src/native_window/native_window_ffi.rs
@@ -202,6 +202,14 @@ impl OH_NativeBuffer_MetadataKey {
 #[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct OH_NativeBuffer_MetadataKey(pub ::core::ffi::c_uint);
+/// Defines the ipc parcel.
+///
+///
+/// Available since API-level: 12
+///
+/// Version: 1.0
+#[cfg(feature = "api-12")]
+#[cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 #[repr(C)]
 pub struct OHIPCParcel {
     _unused: [u8; 0],


### PR DESCRIPTION
The documentation is associated with the typedef, which bindgen didn't generate due to name conflict with the type itself.
[Patch](https://github.com/rust-lang/rust-bindgen/pull/3122) was submitted upstream to fallback to the documentation of the type alias in such cases.