### PR TITLE
CI: Add integrity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,25 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo fmt --check
       - run: cargo clippy
+
+  integrity:
+    name: Integrity Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - name: Setup OpenHarmony SDK
+        uses: openharmony-rs/setup-ohos-sdk@v0.2
+        with:
+          version: 5.0.2
+      - name: Generate bindings
+        run: ./scripts/generate_bindings.sh
+      - name: Check integrity
+        run: git diff --exit-code
+
   build-toolchains:
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "ohos-deviceinfo-sys"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "document-features",
 ]
@@ -100,6 +100,14 @@ name = "ohos-input-sys"
 version = "0.2.0"
 dependencies = [
  "document-features",
+]
+
+[[package]]
+name = "ohos-media-sys"
+version = "0.0.1"
+dependencies = [
+ "document-features",
+ "ohos-sys-opaque-types",
 ]
 
 [[package]]

--- a/scripts/generator/Cargo.lock
+++ b/scripts/generator/Cargo.lock
@@ -70,6 +70,7 @@ checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 [[package]]
 name = "bindgen"
 version = "0.71.1"
+source = "git+https://github.com/openharmony-rs/rust-bindgen.git?branch=jschwender%2Fdoc_cfg#3d12dd75e510814951a7232fd3a3a4c1131770b1"
 dependencies = [
  "bitflags",
  "cexpr",


### PR DESCRIPTION
Add a simple integrity check, which checks out the SDK of the specified version, generates the bindings and ensures that the committed bindings match the generated bindings.