### PR TITLE
Library seems to be incorrect.

### DIFF
--- a/components/multimodal-input/src/lib.rs
+++ b/components/multimodal-input/src/lib.rs
@@ -13,7 +13,7 @@
 #![cfg(feature = "api-12")]
 #![cfg_attr(docsrs, doc(cfg(feature = "api-12")))]
 
-#[link(name = "oh_input")]
+#[link(name = "ohinput")]
 extern "C" {}
 
 pub mod axis_type;


### PR DESCRIPTION
The header seems to incorrectly state that the library is liboh_input.
This file does not seem to exit at least on sdk 12 and 14 on windows and
linux I can't find a liboh_input file in
native/sysroot/usr/lib/aarch64-linux-ohos/

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
