### PR TITLE
Generator: Fix deprecated since

### DIFF
--- a/components/multimedia/player_framework/src/avcodec_base/avcodec_base_ffi.rs
+++ b/components/multimedia/player_framework/src/avcodec_base/avcodec_base_ffi.rs
@@ -81,6 +81,7 @@ pub type OH_AVCodecOnStreamChanged = ::core::option::Option<
 /// OH_AVCodecOnNeedInputBuffer
 ///
 /// Available since API-level: 9
+#[deprecated(since = "11")]
 pub type OH_AVCodecOnNeedInputData = ::core::option::Option<
     unsafe extern "C" fn(
         codec: *mut OH_AVCodec,
@@ -112,6 +113,7 @@ pub type OH_AVCodecOnNeedInputData = ::core::option::Option<
 /// OH_AVCodecOnNewOutputBuffer
 ///
 /// Available since API-level: 9
+#[deprecated(since = "11")]
 pub type OH_AVCodecOnNewOutputData = ::core::option::Option<
     unsafe extern "C" fn(
         codec: *mut OH_AVCodec,
@@ -193,6 +195,7 @@ pub type OH_AVCodecOnNewOutputBuffer = ::core::option::Option<
 /// OH_AVCodecCallback
 ///
 /// Available since API-level: 9
+#[deprecated(since = "11")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct OH_AVCodecAsyncCallback {
@@ -456,6 +459,7 @@ impl OH_ScalingMode {
 /// OHScalingModeV2
 ///
 /// Available since API-level: 10
+#[deprecated(since = "14")]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct OH_ScalingMode(pub ::core::ffi::c_uint);
 impl OH_BitsPerSample {
@@ -772,6 +776,7 @@ extern "C" {
     /// **Deprecated** since 11
     ///
     /// Available since API-level: 10
+    #[deprecated(since = "11")]
     pub static mut OH_AVCODEC_MIMETYPE_VIDEO_MPEG4: *const ::core::ffi::c_char;
     /// Enumerates the mime types of cover jpg muxer.
     ///
@@ -883,6 +888,7 @@ extern "C" {
     /// **Deprecated** since 14
     ///
     /// Available since API-level: 9
+    #[deprecated(since = "14")]
     pub static mut OH_ED_KEY_TIME_STAMP: *const ::core::ffi::c_char;
     /// Key for endOfStream in surface's extraData, value type is bool.
     ///
@@ -892,6 +898,7 @@ extern "C" {
     /// **Deprecated** since 14
     ///
     /// Available since API-level: 9
+    #[deprecated(since = "14")]
     pub static mut OH_ED_KEY_EOS: *const ::core::ffi::c_char;
     /// Key for track type, value type is int32_t, see [`OH_MediaType`].
     ///
@@ -1200,6 +1207,7 @@ extern "C" {
     /// OH_NativeWindow_NativeWindowSetScalingModeV2
     ///
     /// Available since API-level: 10
+    #[deprecated(since = "14")]
     pub static mut OH_MD_KEY_SCALING_MODE: *const ::core::ffi::c_char;
     /// Key for max input buffer count, value type is int32_t.
     ///

--- a/components/multimedia/player_framework/src/avdemuxer/avdemuxer_ffi.rs
+++ b/components/multimedia/player_framework/src/avdemuxer/avdemuxer_ffi.rs
@@ -38,6 +38,7 @@ pub struct DRM_MediaKeySystemInfo {
 /// Available since API-level: 11
 #[cfg(feature = "api-11")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
+#[deprecated(since = "14")]
 pub type DRM_MediaKeySystemInfoCallback =
     ::core::option::Option<unsafe extern "C" fn(mediaKeySystemInfo: *mut DRM_MediaKeySystemInfo)>;
 /// Call back will be invoked when updating DRM information.
@@ -173,6 +174,7 @@ extern "C" {
     /// OH_AVDemuxer_ReadSampleBuffer
     ///
     /// Available since API-level: 10
+    #[deprecated(since = "11")]
     pub fn OH_AVDemuxer_ReadSample(
         demuxer: *mut OH_AVDemuxer,
         trackIndex: u32,
@@ -258,6 +260,7 @@ extern "C" {
     /// Available since API-level: 11
     #[cfg(feature = "api-11")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
+    #[deprecated(since = "14")]
     pub fn OH_AVDemuxer_SetMediaKeySystemInfoCallback(
         demuxer: *mut OH_AVDemuxer,
         callback: DRM_MediaKeySystemInfoCallback,

--- a/components/multimedia/player_framework/src/avmemory/avmemory_ffi.rs
+++ b/components/multimedia/player_framework/src/avmemory/avmemory_ffi.rs
@@ -32,6 +32,7 @@ extern "C" {
     /// OH_AVBuffer_Create
     ///
     /// Available since API-level: 10
+    #[deprecated(since = "11")]
     pub fn OH_AVMemory_Create(size: i32) -> *mut OH_AVMemory;
     /// Get the memory's virtual address
     ///
@@ -51,6 +52,7 @@ extern "C" {
     /// Available since API-level: 9
     ///
     /// Version: 1.0
+    #[deprecated(since = "11")]
     pub fn OH_AVMemory_GetAddr(mem: *mut OH_AVMemory) -> *mut u8;
     /// Get the memory's size
     ///
@@ -70,6 +72,7 @@ extern "C" {
     /// Available since API-level: 9
     ///
     /// Version: 1.0
+    #[deprecated(since = "11")]
     pub fn OH_AVMemory_GetSize(mem: *mut OH_AVMemory) -> i32;
     /// Clear the internal resources of the memory and destroy the memory
     /// instance
@@ -89,5 +92,6 @@ extern "C" {
     /// OH_AVBuffer_Destroy
     ///
     /// Available since API-level: 10
+    #[deprecated(since = "11")]
     pub fn OH_AVMemory_Destroy(mem: *mut OH_AVMemory) -> OH_AVErrCode;
 }

--- a/components/multimedia/player_framework/src/avplayer/avplayer_ffi.rs
+++ b/components/multimedia/player_framework/src/avplayer/avplayer_ffi.rs
@@ -639,6 +639,7 @@ extern "C" {
     /// Version: 1.0
     #[cfg(feature = "api-11")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
+    #[deprecated(since = "12")]
     pub fn OH_AVPlayer_SetPlayerCallback(
         player: *mut OH_AVPlayer,
         callback: AVPlayerCallback,

--- a/components/multimedia/player_framework/src/avplayer_base/avplayer_base_ffi.rs
+++ b/components/multimedia/player_framework/src/avplayer_base/avplayer_base_ffi.rs
@@ -203,6 +203,7 @@ pub struct AVPlayerBufferingType(pub ::core::ffi::c_uint);
 /// Version: 1.0
 #[cfg(feature = "api-11")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
+#[deprecated(since = "12")]
 pub type OH_AVPlayerOnInfo = ::core::option::Option<
     unsafe extern "C" fn(player: *mut OH_AVPlayer, type_: AVPlayerOnInfoType, extra: i32),
 >;
@@ -249,6 +250,7 @@ pub type OH_AVPlayerOnInfoCallback = ::core::option::Option<
 /// Version: 1.0
 #[cfg(feature = "api-11")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
+#[deprecated(since = "12")]
 pub type OH_AVPlayerOnError = ::core::option::Option<
     unsafe extern "C" fn(
         player: *mut OH_AVPlayer,
@@ -299,6 +301,7 @@ pub type OH_AVPlayerOnErrorCallback = ::core::option::Option<
 /// Version: 1.0
 #[cfg(feature = "api-11")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
+#[deprecated(since = "12")]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct AVPlayerCallback {

--- a/components/rawfile/src/raw_file/raw_file_ffi.rs
+++ b/components/rawfile/src/raw_file/raw_file_ffi.rs
@@ -144,6 +144,7 @@ extern "C" {
     ///
     /// **Deprecated** since 12
     /// OH_ResourceManager_GetRawFileDescriptorData
+    #[deprecated(since = "12")]
     pub fn OH_ResourceManager_GetRawFileDescriptor(
         rawFile: *const RawFile,
         descriptor: *mut RawFileDescriptor,
@@ -189,6 +190,7 @@ extern "C" {
     ///
     /// **Deprecated** since 12
     /// OH_ResourceManager_ReleaseRawFileDescriptorData
+    #[deprecated(since = "12")]
     pub fn OH_ResourceManager_ReleaseRawFileDescriptor(
         descriptor: *const RawFileDescriptor,
     ) -> bool;

--- a/components/window/src/native_image/native_image/native_image_ffi.rs
+++ b/components/window/src/native_image/native_image/native_image_ffi.rs
@@ -191,6 +191,7 @@ extern "C" {
     ///
     /// **Deprecated** since 12
     /// OH_NativeImage_GetTransformMatrixV2
+    #[deprecated(since = "12")]
     pub fn OH_NativeImage_GetTransformMatrix(image: *mut OH_NativeImage, matrix: *mut f32) -> i32;
     /// Return the native image's surface id.
     ///

--- a/components/window/src/native_window/external_window/external_window_ffi.rs
+++ b/components/window/src/native_window/external_window/external_window_ffi.rs
@@ -342,6 +342,7 @@ extern "C" {
     /// Version: 1.0
     ///
     /// **Deprecated** since 12
+    #[deprecated(since = "12")]
     pub fn OH_NativeWindow_CreateNativeWindow(
         pSurface: *mut ::core::ffi::c_void,
     ) -> *mut OHNativeWindow;
@@ -379,6 +380,7 @@ extern "C" {
     ///
     /// **Deprecated** since 12
     /// OH_NativeWindow_CreateNativeWindowBufferFromNativeBuffer
+    #[deprecated(since = "12")]
     pub fn OH_NativeWindow_CreateNativeWindowBufferFromSurfaceBuffer(
         pSurfaceBuffer: *mut ::core::ffi::c_void,
     ) -> *mut OHNativeWindowBuffer;
@@ -518,6 +520,7 @@ extern "C" {
     /// OH_NativeWindow_GetLastFlushedBufferV2
     #[cfg(feature = "api-11")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
+    #[deprecated(since = "12")]
     pub fn OH_NativeWindow_GetLastFlushedBuffer(
         window: *mut OHNativeWindow,
         buffer: *mut *mut OHNativeWindowBuffer,

--- a/scripts/generator/src/main.rs
+++ b/scripts/generator/src/main.rs
@@ -100,6 +100,10 @@ fn parse_deprecated_since(line: &str) -> Result<Option<OpenHarmonyApiLevel>, Par
     if line.trim() == "@deprecated" {
         return Ok(None);
     }
+    if let Some((_, rhs)) = line.trim().split_once("**Deprecated** since") {
+        return Ok(Some(OpenHarmonyApiLevel::try_from(rhs.trim())?));
+    }
+    
     let (_, rhs) = line
         .split_once("@deprecated")
         .ok_or_else(|| ParseDeprecatedError::InvalidLine(line.to_string()))?;
@@ -185,7 +189,7 @@ impl bindgen::callbacks::ParseCallbacks for DoxygenCommentCb {
             }
         }
 
-        if let Some(deprecated_line) = comment.lines().find(|line| line.contains("@deprecated")) {
+        if let Some(deprecated_line) = comment.lines().find(|line| line.contains("@deprecated") || line.contains("**Deprecated**")) {
             let deprecated_since = parse_deprecated_since(deprecated_line).expect("Parse failed");
             let deprecated_opt =
                 deprecated_since.map(|since| format!("since = \"{}\"", since as u32));


### PR DESCRIPTION
Sometimes comments are already processed, before the parser callback receives it. Instead of staring deeper into bindgen, just also handle that case.