### PR TITLE
Fix skipped single-header files

### DIFF
--- a/components/hilog/src/hilog_ffi.rs
+++ b/components/hilog/src/hilog_ffi.rs
@@ -157,4 +157,14 @@ extern "C" {
     #[cfg(feature = "api-11")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-11")))]
     pub fn OH_LOG_SetCallback(callback: LogCallback);
+    /// Sets the lowest log level of the current application process.
+    ///
+    /// # Arguments
+    ///
+    /// * `level` - log level
+    ///
+    /// Available since API-level: 15
+    #[cfg(feature = "api-15")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "api-15")))]
+    pub fn OH_LOG_SetMinLogLevel(level: LogLevel);
 }

--- a/components/xcomponent/src/lib.rs
+++ b/components/xcomponent/src/lib.rs
@@ -54,7 +54,7 @@ impl XcomponentResult {
 // may change.
 #[allow(dead_code)]
 const ASSERT_SIZE_OK: () =
-    assert!(size_of::<XcomponentResult>() == size_of::<xcomponent_result_ffi::_bindgen_ty_11>());
+    assert!(size_of::<XcomponentResult>() == size_of::<xcomponent_result_ffi::_bindgen_ty_13>());
 
 #[cfg(feature = "keyboard-types")]
 #[cfg_attr(docsrs, doc(cfg(feature = "keyboard-types")))]

--- a/components/xcomponent/src/xcomponent_result_ffi.rs
+++ b/components/xcomponent/src/xcomponent_result_ffi.rs
@@ -6,15 +6,15 @@
 #![allow(unused)]
 
 /// Successful.
-pub const OH_NATIVEXCOMPONENT_RESULT_SUCCESS: _bindgen_ty_11 = 0;
+pub const OH_NATIVEXCOMPONENT_RESULT_SUCCESS: _bindgen_ty_13 = 0;
 /// Failed.
-pub const OH_NATIVEXCOMPONENT_RESULT_FAILED: _bindgen_ty_11 = -1;
+pub const OH_NATIVEXCOMPONENT_RESULT_FAILED: _bindgen_ty_13 = -1;
 /// Invalid parameters.
-pub const OH_NATIVEXCOMPONENT_RESULT_BAD_PARAMETER: _bindgen_ty_11 = -2;
+pub const OH_NATIVEXCOMPONENT_RESULT_BAD_PARAMETER: _bindgen_ty_13 = -2;
 /// Enumerates the API access states.
 ///
 ///
 /// Available since API-level: 8
 ///
 /// Version: 1.0
-pub type _bindgen_ty_11 = ::core::ffi::c_int;
+pub type _bindgen_ty_13 = ::core::ffi::c_int;

--- a/scripts/generator/src/main.rs
+++ b/scripts/generator/src/main.rs
@@ -339,7 +339,7 @@ fn generate_bindings(sdk_native_dir: &Path, api_version: u32) -> anyhow::Result<
         if only_gen_module
             .as_ref()
             .and_then(|name| header_filename_str.contains(name).then_some(()))
-            .is_none()
+            .is_some()
         {
             continue;
         }


### PR DESCRIPTION
An inverted check added in e55531 caused single header files to always be skipped