### PR TITLE
Add patch feature for bindings

### DIFF
--- a/components/window/src/native_buffer/native_buffer/native_buffer_ffi.rs
+++ b/components/window/src/native_buffer/native_buffer/native_buffer_ffi.rs
@@ -38,11 +38,11 @@ impl ::core::ops::BitAndAssign for OH_NativeBuffer_Usage {
     }
 }
 impl OH_NativeBuffer_Usage {
-    /// < CPU read buffer */
+    /// CPU read buffer
     pub const NATIVEBUFFER_USAGE_CPU_READ: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(1);
-    /// < CPU write memory */
+    /// CPU write memory
     pub const NATIVEBUFFER_USAGE_CPU_WRITE: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(2);
-    /// < Direct memory access (DMA) buffer */
+    /// Direct memory access (DMA) buffer
     pub const NATIVEBUFFER_USAGE_MEM_DMA: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(8);
     /// MMZ with cache
     ///
@@ -50,14 +50,14 @@ impl OH_NativeBuffer_Usage {
     #[cfg(feature = "api-20")]
     #[cfg_attr(docsrs, doc(cfg(feature = "api-20")))]
     pub const NATIVEBUFFER_USAGE_MEM_MMZ_CACHE: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(32);
-    /// < For GPU write case */
+    /// For GPU write case
     pub const NATIVEBUFFER_USAGE_HW_RENDER: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(256);
-    /// < For GPU read case */
+    /// For GPU read case
     pub const NATIVEBUFFER_USAGE_HW_TEXTURE: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(512);
-    /// < Often be mapped for direct CPU reads */
+    /// Often be mapped for direct CPU reads
     pub const NATIVEBUFFER_USAGE_CPU_READ_OFTEN: OH_NativeBuffer_Usage =
         OH_NativeBuffer_Usage(65536);
-    /// < 512 bytes alignment */
+    /// 512 bytes alignment
     pub const NATIVEBUFFER_USAGE_ALIGNMENT_512: OH_NativeBuffer_Usage =
         OH_NativeBuffer_Usage(262144);
 }

--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 # Deprecated script. Use the generator written in Rust instead.
+# The generator also runs `cargo +nightly fmt` and applies any patches in
+# `scripts/generator/patches/`.
 
 set -eux
 
 ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )"/.. &> /dev/null && pwd )
 
 (cd "${ROOT_DIR}/scripts/generator" && cargo run )
-
-cd "${ROOT_DIR}"
-cargo +nightly fmt

--- a/scripts/generator/patches/README.md
+++ b/scripts/generator/patches/README.md
@@ -1,0 +1,33 @@
+# Generator patches
+
+Unified-diff patches applied by `scripts/generator` after bindgen and
+`cargo +nightly fmt`. Use one when the bindgen output cannot be fixed by tweaking
+the generator config — most commonly when an upstream C header has malformed
+doxygen comments that bindgen attaches to the wrong member.
+
+## Conventions
+
+- Each `*.patch` is a unified diff with paths relative to the repo root and a
+  `--- a/PATH` / `+++ b/PATH` header. Applied via `git apply` from the repo root.
+- Patches are applied in alphabetical order.
+- The patch's "before" side must match the freshly generated, formatted output
+  exactly. If bindgen output drifts, the patch will fail loudly and must be
+  regenerated.
+- Name patches after the file/issue they fix, e.g.
+  `native_buffer_usage_comments.patch`.
+
+## Generating a new patch
+
+```sh
+REL=path/to/generated_ffi.rs
+cp "$REL" /tmp/before.rs
+# ... hand-edit "$REL" into the desired state ...
+diff -u --label "a/$REL" --label "b/$REL" /tmp/before.rs "$REL" \
+    > scripts/generator/patches/<descriptive-name>.patch
+```
+
+Confirm before committing:
+
+```sh
+git apply --check scripts/generator/patches/<descriptive-name>.patch
+```

--- a/scripts/generator/patches/native_buffer_usage_comments.patch
+++ b/scripts/generator/patches/native_buffer_usage_comments.patch
@@ -1,0 +1,48 @@
+--- a/components/window/src/native_buffer/native_buffer/native_buffer_ffi.rs
++++ b/components/window/src/native_buffer/native_buffer/native_buffer_ffi.rs
+@@ -38,33 +38,26 @@
+     }
+ }
+ impl OH_NativeBuffer_Usage {
++    /// CPU read buffer
+     pub const NATIVEBUFFER_USAGE_CPU_READ: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(1);
+-    /// < CPU read buffer */
++    /// CPU write memory
+     pub const NATIVEBUFFER_USAGE_CPU_WRITE: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(2);
+-    /// < CPU write memory */
++    /// Direct memory access (DMA) buffer
+     pub const NATIVEBUFFER_USAGE_MEM_DMA: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(8);
+-    /// < Direct memory access (DMA) buffer */
+-    /// **
+-    /// * MMZ with cache
+-    /// * @since 20
+-    /// */
+-    #[cfg(feature = "api-20")]
+-    #[cfg_attr(docsrs, doc(cfg(feature = "api-20")))]
+-    pub const NATIVEBUFFER_USAGE_MEM_MMZ_CACHE: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(32);
+-    /// < Direct memory access (DMA) buffer */
+-    /// **
+-    /// * MMZ with cache
+-    /// * @since 20
+-    /// */
++    /// MMZ with cache
++    ///
++    /// Available since API-level: 20
+     #[cfg(feature = "api-20")]
+     #[cfg_attr(docsrs, doc(cfg(feature = "api-20")))]
+-    pub const NATIVEBUFFER_USAGE_HW_RENDER: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(256);
+-    /// < For GPU write case */
++    pub const NATIVEBUFFER_USAGE_MEM_MMZ_CACHE: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(32);
++    /// For GPU write case
++    pub const NATIVEBUFFER_USAGE_HW_RENDER: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(256);
++    /// For GPU read case
+     pub const NATIVEBUFFER_USAGE_HW_TEXTURE: OH_NativeBuffer_Usage = OH_NativeBuffer_Usage(512);
+-    /// < For GPU read case */
++    /// Often be mapped for direct CPU reads
+     pub const NATIVEBUFFER_USAGE_CPU_READ_OFTEN: OH_NativeBuffer_Usage =
+         OH_NativeBuffer_Usage(65536);
+-    /// < Often be mapped for direct CPU reads */
++    /// 512 bytes alignment
+     pub const NATIVEBUFFER_USAGE_ALIGNMENT_512: OH_NativeBuffer_Usage =
+         OH_NativeBuffer_Usage(262144);
+ }

--- a/scripts/generator/src/header_conf.rs
+++ b/scripts/generator/src/header_conf.rs
@@ -33,6 +33,10 @@ pub(crate) fn get_bindings_config(_api_version: u32) -> Vec<BindingConf> {
                     .no_copy("napi_extended_error_info")
                     .no_copy("napi_node_version")
                     .no_copy("napi_module")
+                    // `NAPI_AUTO_LENGTH` is `#define NAPI_AUTO_LENGTH SIZE_MAX`. 
+                    // Usages expect `size_t`.
+                    .blocklist_var("NAPI_AUTO_LENGTH")
+                    .raw_line("pub const NAPI_AUTO_LENGTH: usize = usize::MAX;")
                     .raw_line("pub use ohos_sys_opaque_types::{napi_env, napi_value};")
             }),
         },

--- a/scripts/generator/src/main.rs
+++ b/scripts/generator/src/main.rs
@@ -6,6 +6,7 @@ mod opaque_types;
 use crate::dir_conf::get_module_bindings_config;
 use crate::header_conf::get_bindings_config;
 use anyhow::{anyhow, bail, Context};
+use std::process::Command;
 use bindgen::callbacks::EnumVariantValue;
 use bindgen::{CodeGenAttributes, EnumVariation, Formatter};
 use log::{debug, error, info, warn};
@@ -431,6 +432,86 @@ fn generate_bindings(sdk_native_dir: &Path, api_version: u32) -> anyhow::Result<
     Ok(())
 }
 
+/// Run `cargo +nightly fmt` against the workspace at `root_dir`.
+fn run_cargo_fmt(root_dir: &Path) -> anyhow::Result<()> {
+    info!("Running cargo +nightly fmt");
+    let status = Command::new("cargo")
+        .current_dir(root_dir)
+        .args(["+nightly", "fmt"])
+        .status()
+        .context("Failed to spawn `cargo +nightly fmt`")?;
+    if !status.success() {
+        bail!("`cargo +nightly fmt` failed with status {status}");
+    }
+    Ok(())
+}
+
+/// Apply every `*.patch` file in `patches_dir` (sorted by filename) against
+/// `root_dir` via `git apply`.
+///
+/// Patches exist to fix specific bindgen output that we cannot express through
+/// the generator config — e.g. C headers with malformed doxygen comments where
+/// the comment ends up attached to the wrong member.
+///
+/// Convention: each patch is a unified diff with paths relative to the repo
+/// root and a `--- a/PATH` / `+++ b/PATH` header. Generate one with:
+///
+/// ```sh
+/// REL=path/to/file.rs
+/// cp "$REL" /tmp/before.rs
+/// # ... hand-edit "$REL" into the desired state ...
+/// diff -u --label "a/$REL" --label "b/$REL" /tmp/before.rs "$REL" \
+///     > scripts/generator/patches/<descriptive-name>.patch
+/// ```
+fn apply_patches(root_dir: &Path, patches_dir: &Path) -> anyhow::Result<()> {
+    if !patches_dir.is_dir() {
+        debug!("No patches directory at {}, skipping.", patches_dir.display());
+        return Ok(());
+    }
+    let mut patches: Vec<PathBuf> = fs::read_dir(patches_dir)
+        .with_context(|| format!("Failed to read {}", patches_dir.display()))?
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("patch"))
+        .collect();
+    patches.sort();
+
+    for patch in patches {
+        let name = patch.file_name().unwrap().to_string_lossy().into_owned();
+
+        // Idempotency: if the patch already applies in reverse, the file is
+        // already in the patched state (e.g. ONLY_MODULE skipped regenerating
+        // it). Skip rather than fail.
+        let reverse_check = Command::new("git")
+            .current_dir(root_dir)
+            .args(["apply", "-R", "--check"])
+            .arg(&patch)
+            .output()
+            .with_context(|| format!("Failed to spawn `git apply -R --check` for {name}"))?;
+        if reverse_check.status.success() {
+            info!("Patch already applied, skipping: {name}");
+            continue;
+        }
+
+        info!("Applying patch: {name}");
+        let output = Command::new("git")
+            .current_dir(root_dir)
+            .args(["apply", "--whitespace=nowarn"])
+            .arg(&patch)
+            .output()
+            .with_context(|| format!("Failed to spawn `git apply` for {name}"))?;
+        if !output.status.success() {
+            bail!(
+                "Failed to apply patch {name}.\nstderr:\n{}\n\
+                 Likely the bindgen output drifted from the patch context. \
+                 Regenerate the patch — see the doc comment on `apply_patches`.",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+    Ok(())
+}
+
 fn main() -> anyhow::Result<()> {
     env_logger::init();
     let sdk_native_dir = std::env::var_os("OHOS_SDK_NATIVE").context(
@@ -456,6 +537,16 @@ fn main() -> anyhow::Result<()> {
     std::env::set_var("LIBCLANG_PATH", libclang_path);
     std::env::set_var("CLANG_PATH", clang_path);
     generate_bindings(&sdk_native_dir, api_version)?;
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let root_dir = manifest_dir
+        .parent()
+        .and_then(|d| d.parent())
+        .ok_or(anyhow!("Could not determine root directory"))?
+        .canonicalize()
+        .context("Could not canonicalize root directory")?;
+    run_cargo_fmt(&root_dir)?;
+    apply_patches(&root_dir, &manifest_dir.join("patches"))?;
 
     Ok(())
 }

--- a/src/napi/napi_ffi.rs
+++ b/src/napi/napi_ffi.rs
@@ -3,11 +3,11 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+pub const NAPI_AUTO_LENGTH: usize = usize::MAX;
 pub use ohos_sys_opaque_types::{napi_env, napi_value};
 
 pub const NAPI_VERSION: u32 = 8;
 pub const NAPI_VERSION_EXPERIMENTAL: u32 = 2147483647;
-pub const NAPI_AUTO_LENGTH: i32 = -1;
 pub const NAPI_MODULE_VERSION: u32 = 1;
 impl napi_qos_t {
     pub const napi_qos_background: napi_qos_t = napi_qos_t(0);


### PR DESCRIPTION
For now this only fixes the `OH_NativeBuffer_Usage` doc comments. The c headers don't use doxygen correctly, so we patch it manually.